### PR TITLE
chore(release): bump to 1.0.0-beta.11

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -1,10 +1,10 @@
 # Ack - Schema Validation Library for Dart
 
-> A schema validation library for Dart and Flutter with a fluent API, code generation via `@AckType` and `@AckModel` annotations, and Dart 3 extension types for zero-cost type-safe wrappers over validated data. Version 1.0.0-beta.10.
+> A schema validation library for Dart and Flutter with a fluent API, code generation via `@AckType` and `@AckModel` annotations, and Dart 3 extension types for zero-cost type-safe wrappers over validated data. Version 1.0.0-beta.11.
 
 ## Overview
 
-Ack (short for "acknowledge") is a schema validation library for Dart and Flutter that enables data validation with a simple, fluent API. Version 1.0.0-beta.10 is the current published baseline.
+Ack (short for "acknowledge") is a schema validation library for Dart and Flutter that enables data validation with a simple, fluent API. Version 1.0.0-beta.11 is the current published baseline.
 
 **Repository**: https://github.com/btwld/ack
 **Documentation**: https://docs.page/btwld/ack
@@ -819,11 +819,11 @@ sealed class SchemaResult<T extends Object> {
 ```yaml
 # pubspec.yaml
 dependencies:
-  ack: ^1.0.0-beta.10
-  ack_annotations: ^1.0.0-beta.10
+  ack: ^1.0.0-beta.11
+  ack_annotations: ^1.0.0-beta.11
 
 dev_dependencies:
-  ack_generator: ^1.0.0-beta.10
+  ack_generator: ^1.0.0-beta.11
   build_runner: ^2.4.0
 ```
 
@@ -964,7 +964,7 @@ Converts Ack schemas to Firebase AI Schema format for structured output generati
 ```yaml
 # pubspec.yaml
 dependencies:
-  ack_firebase_ai: ^1.0.0-beta.10
+  ack_firebase_ai: ^1.0.0-beta.11
 ```
 
 ```dart
@@ -997,7 +997,7 @@ Converts Ack schemas to json_schema_builder format for JSON Schema Draft 2020-12
 ```yaml
 # pubspec.yaml
 dependencies:
-  ack_json_schema_builder: ^1.0.0-beta.10
+  ack_json_schema_builder: ^1.0.0-beta.11
 ```
 
 ```dart

--- a/packages/ack/CHANGELOG.md
+++ b/packages/ack/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0-beta.11
+
+* See [release notes](https://github.com/btwld/ack/releases/tag/v1.0.0-beta.11) for details.
+
 ## 1.0.0-beta.10
 
 * See [release notes](https://github.com/btwld/ack/releases/tag/v1.0.0-beta.10) for details.

--- a/packages/ack/pubspec.yaml
+++ b/packages/ack/pubspec.yaml
@@ -1,6 +1,6 @@
 name: ack
 description: A simple validation library for Dart
-version: 1.0.0-beta.10
+version: 1.0.0-beta.11
 repository: https://github.com/btwld/ack
 issue_tracker: https://github.com/btwld/ack/issues
 homepage: https://docs.page/btwld/ack

--- a/packages/ack_annotations/CHANGELOG.md
+++ b/packages/ack_annotations/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0-beta.11
+
+* See [release notes](https://github.com/btwld/ack/releases/tag/v1.0.0-beta.11) for details.
+
 ## 1.0.0-beta.10
 
 * See [release notes](https://github.com/btwld/ack/releases/tag/v1.0.0-beta.10) for details.

--- a/packages/ack_annotations/pubspec.yaml
+++ b/packages/ack_annotations/pubspec.yaml
@@ -1,6 +1,6 @@
 name: ack_annotations
 description: Annotations for Ack schema code generation
-version: 1.0.0-beta.10
+version: 1.0.0-beta.11
 repository: https://github.com/btwld/ack
 resolution: workspace
 

--- a/packages/ack_firebase_ai/CHANGELOG.md
+++ b/packages/ack_firebase_ai/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0-beta.11
+
+* See [release notes](https://github.com/btwld/ack/releases/tag/v1.0.0-beta.11) for details.
+
 ## 1.0.0-beta.10
 
 * See [release notes](https://github.com/btwld/ack/releases/tag/v1.0.0-beta.10) for details.

--- a/packages/ack_firebase_ai/pubspec.yaml
+++ b/packages/ack_firebase_ai/pubspec.yaml
@@ -1,6 +1,6 @@
 name: ack_firebase_ai
 description: Firebase AI (Gemini) schema converter for ACK validation library
-version: 1.0.0-beta.10
+version: 1.0.0-beta.11
 repository: https://github.com/btwld/ack
 issue_tracker: https://github.com/btwld/ack/issues
 resolution: workspace
@@ -12,7 +12,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  ack: ^1.0.0-beta.10
+  ack: ^1.0.0-beta.11
   firebase_ai: '>=3.4.0 <5.0.0'  # Tested with 3.4.0, compatible with 3.x-4.x
   meta: ^1.15.0
 

--- a/packages/ack_generator/CHANGELOG.md
+++ b/packages/ack_generator/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0-beta.11
+
+* See [release notes](https://github.com/btwld/ack/releases/tag/v1.0.0-beta.11) for details.
+
 ## 1.0.0-beta.10
 
 * See [release notes](https://github.com/btwld/ack/releases/tag/v1.0.0-beta.10) for details.

--- a/packages/ack_generator/pubspec.yaml
+++ b/packages/ack_generator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: ack_generator
 description: Code generator for Ack schema validation models
-version: 1.0.0-beta.10
+version: 1.0.0-beta.11
 repository: https://github.com/btwld/ack
 issue_tracker: https://github.com/btwld/ack/issues
 resolution: workspace
@@ -16,8 +16,8 @@ dependencies:
   code_builder: ^4.10.0
   
   # Ack packages (versions are overridden locally by Melos)
-  ack: ^1.0.0-beta.10
-  ack_annotations: ^1.0.0-beta.10
+  ack: ^1.0.0-beta.11
+  ack_annotations: ^1.0.0-beta.11
   
   # Utilities
   collection: ^1.18.0

--- a/packages/ack_json_schema_builder/CHANGELOG.md
+++ b/packages/ack_json_schema_builder/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0-beta.11
+
+* See [release notes](https://github.com/btwld/ack/releases/tag/v1.0.0-beta.11) for details.
+
 ## 1.0.0-beta.10
 
 * See [release notes](https://github.com/btwld/ack/releases/tag/v1.0.0-beta.10) for details.

--- a/packages/ack_json_schema_builder/pubspec.yaml
+++ b/packages/ack_json_schema_builder/pubspec.yaml
@@ -1,6 +1,6 @@
 name: ack_json_schema_builder
 description: JSON Schema Builder converter for ACK validation library
-version: 1.0.0-beta.10
+version: 1.0.0-beta.11
 repository: https://github.com/btwld/ack
 issue_tracker: https://github.com/btwld/ack/issues
 resolution: workspace
@@ -9,7 +9,7 @@ environment:
   sdk: '>=3.8.0 <4.0.0'
 
 dependencies:
-  ack: ^1.0.0-beta.10
+  ack: ^1.0.0-beta.11
   json_schema_builder: ^0.1.3
   meta: ^1.15.0
 


### PR DESCRIPTION
## Summary

- Bumps all 5 packages (ack, ack_annotations, ack_generator, ack_firebase_ai, ack_json_schema_builder) from 1.0.0-beta.10 to 1.0.0-beta.11
- Updates cross-package dependency constraints to ^1.0.0-beta.11
- Adds new CHANGELOG entries for each package
- Updates version references in llms.txt

## Test plan

- [ ] Verify `dart pub get` resolves successfully at workspace root
- [ ] Tag `v1.0.0-beta.11` after merge to trigger CI publish to pub.dev