### PR TITLE
feat: union-owned discriminator for discriminated schemas

### DIFF
--- a/docs/api-reference/index.mdx
+++ b/docs/api-reference/index.mdx
@@ -204,9 +204,10 @@ Schema for polymorphic validation based on a string discriminator property.
 
 - Branch schemas normally omit the discriminator field.
 - The boundary payload must still contain the discriminator key.
-- If a branch schema includes the discriminator field, it must accept the
-  branch map key; conflicting schemas are rejected. For generated types, this
-  compatibility must be statically provable.
+- If a branch schema includes the discriminator field, it must be
+  `Ack.literal(...)` matching the branch key or `Ack.enumString(...)`
+  containing it. Broad, transformed, refined, or otherwise restrictive
+  discriminator fields are rejected.
 - Exported and generated schemas expose each branch discriminator as an exact
   literal.
 - Generated subtype `parse()` and `safeParse()` methods validate through the

--- a/docs/api-reference/index.mdx
+++ b/docs/api-reference/index.mdx
@@ -2,7 +2,9 @@
 title: API Reference
 ---
 
-This page provides a quick reference for the core Ack classes, methods, and annotations. For detailed explanations and usage examples, refer to the specific guides linked below.
+This page provides a quick reference for the core Ack classes, methods, and
+annotations. For detailed explanations and usage examples, refer to the
+specific guides linked below.
 
 ## Core `Ack` Class
 
@@ -14,11 +16,19 @@ Entry point for creating schemas. See [Schema Types](../core-concepts/schemas.md
 - `Ack.boolean()`: Creates a `BooleanSchema` for validating booleans.
 - `Ack.list(AckSchema itemSchema)`: Creates a `ListSchema` for validating arrays.
 - `Ack.object(Map<String, AckSchema> properties)`: Creates an `ObjectSchema` for validating objects.
-- `Ack.enumValues(List<T> values)`: Creates an `EnumSchema<T>` for Dart enum types. Accepts enum instances, string names, or indices. **Preferred over `enumString` when a Dart enum exists.**
-- `Ack.enumString(List<String> values)`: Creates a `StringSchema` constrained to the given values. For ad-hoc string lists without a backing Dart enum.
+- `Ack.enumValues(List<T> values)`: Creates an `EnumSchema<T>` for Dart enum
+  types. Accepts enum instances, string names, or indices. **Preferred over
+  `enumString` when a Dart enum exists.**
+- `Ack.enumString(List<String> values)`: Creates a `StringSchema` constrained
+  to the given values. For ad-hoc string lists without a backing Dart enum.
 - `Ack.anyOf(List<AckSchema> schemas)`: Creates an `AnyOfSchema` for union types.
 - `Ack.any()`: Creates an `AnySchema` that accepts any value.
-- `Ack.discriminated<T extends Object>({required String discriminatorKey, required Map<String, AckSchema<T>> schemas})`: Creates a discriminated union schema. Branches may be plain `ObjectSchema` or transformed schemas whose base is an `ObjectSchema`.
+- `Ack.discriminated<T extends Object>(...)`: Creates a discriminated union
+  schema. Branches may be plain `ObjectSchema` or transformed schemas whose
+  base is an `ObjectSchema`. The union owns the discriminator: branches normally
+  omit it, boundary payloads must include it, compatible branch discriminator
+  fields are allowed, and conflicts are rejected. Exported/generated branches
+  expose the exact branch literal.
 
 ## `AckSchema<T>` (Base Class)
 
@@ -188,6 +198,20 @@ See [Schema Types](../core-concepts/schemas.mdx) for the full catalogue,
 including helpers like `Ack.date()`, `Ack.literal()`, and rich list/object
 combinators.
 
+### `Ack.discriminated(...)`
+
+Schema for polymorphic validation based on a string discriminator property.
+
+- Branch schemas normally omit the discriminator field.
+- The boundary payload must still contain the discriminator key.
+- If a branch schema includes the discriminator field, it must accept the
+  branch map key; conflicting schemas are rejected. For generated types, this
+  compatibility must be statically provable.
+- Exported and generated schemas expose each branch discriminator as an exact
+  literal.
+- Generated subtype `parse()` and `safeParse()` methods validate through the
+  union's effective branch.
+
 ## Code Generation Annotations
 
 Use the [`ack_generator`](https://pub.dev/packages/ack_generator) builder to
@@ -252,7 +276,11 @@ Schema for union types (value must match one of several schemas).
 
 Schema for polymorphic validation based on a discriminator field.
 
-- Created using `Ack.discriminated<T extends Object>({required String discriminatorKey, required Map<String, AckSchema<T>> schemas})`
+- Created using `Ack.discriminated<T extends Object>(...)` with
+  `discriminatorKey` and `schemas`.
+- `effectiveBranch(String discriminatorValue)`: Returns the branch schema with
+  the discriminator injected as the exact branch literal. Generated subtypes use
+  this to validate a specific branch.
 
 ### `AnySchema`
 

--- a/docs/core-concepts/typesafe-schemas.mdx
+++ b/docs/core-concepts/typesafe-schemas.mdx
@@ -66,8 +66,8 @@ Unsupported helpers include `Ack.any()` and `Ack.anyOf()`.
 - each branch is non-nullable
 - each branch is declared in the same library as the base
 - branch schemas normally omit the discriminator field
-- if a branch includes the discriminator field, it must be statically provable
-  that the field accepts the branch key
+- if a branch includes the discriminator field, it must be `Ack.literal(...)`
+  matching the branch key or `Ack.enumString(...)` containing the branch key
 
 Example:
 
@@ -95,7 +95,7 @@ final petSchema = Ack.discriminated(
 `Ack.discriminated(...)` owns the discriminator property. Boundary payloads
 must still include the discriminator key, but branch schemas should usually
 omit it. If a branch schema includes the discriminator field, it must be
-statically provable as compatible with the branch map key:
+an exact literal or enum containing the branch map key:
 
 ```dart
 @AckType()
@@ -106,9 +106,10 @@ final catSchema = Ack.object({
 ```
 
 Conflicting discriminator fields are rejected. Exported and generated schemas
-treat the discriminator as an exact literal for each branch, and generated
-subtype `parse()` / `safeParse()` methods validate through the union's
-effective branch.
+treat the discriminator as an exact literal for each branch. Broad
+`Ack.string()`, transformed/refined discriminator fields, and restrictive
+chains are rejected. Generated subtype `parse()` / `safeParse()` methods
+validate through the union's effective branch.
 
 ## Resolution rules
 

--- a/docs/core-concepts/typesafe-schemas.mdx
+++ b/docs/core-concepts/typesafe-schemas.mdx
@@ -65,20 +65,20 @@ Unsupported helpers include `Ack.any()` and `Ack.anyOf()`.
 - each branch is an `@AckType` object schema
 - each branch is non-nullable
 - each branch is declared in the same library as the base
-- the branch discriminator literal matches the branch key
+- branch schemas normally omit the discriminator field
+- if a branch includes the discriminator field, it must be statically provable
+  that the field accepts the branch key
 
 Example:
 
 ```dart
 @AckType()
 final catSchema = Ack.object({
-  'type': Ack.literal('cat'),
   'lives': Ack.integer(),
 });
 
 @AckType()
 final dogSchema = Ack.object({
-  'type': Ack.literal('dog'),
   'breed': Ack.string(),
 });
 
@@ -91,6 +91,24 @@ final petSchema = Ack.discriminated(
   },
 );
 ```
+
+`Ack.discriminated(...)` owns the discriminator property. Boundary payloads
+must still include the discriminator key, but branch schemas should usually
+omit it. If a branch schema includes the discriminator field, it must be
+statically provable as compatible with the branch map key:
+
+```dart
+@AckType()
+final catSchema = Ack.object({
+  'type': Ack.literal('cat'), // allowed, but usually unnecessary
+  'lives': Ack.integer(),
+});
+```
+
+Conflicting discriminator fields are rejected. Exported and generated schemas
+treat the discriminator as an exact literal for each branch, and generated
+subtype `parse()` / `safeParse()` methods validate through the union's
+effective branch.
 
 ## Resolution rules
 

--- a/example/lib/pet.g.dart
+++ b/example/lib/pet.g.dart
@@ -41,17 +41,21 @@ extension type CatType(Map<String, Object?> _data)
   String get type => _data['type'] as String;
 
   static CatType parse(Object? data) {
-    return catSchema.parseAs(
-      data,
-      (validated) => CatType(validated as Map<String, Object?>),
-    );
+    return petSchema
+        .effectiveBranch('cat')
+        .parseAs(
+          data,
+          (validated) => CatType(validated as Map<String, Object?>),
+        );
   }
 
   static SchemaResult<CatType> safeParse(Object? data) {
-    return catSchema.safeParseAs(
-      data,
-      (validated) => CatType(validated as Map<String, Object?>),
-    );
+    return petSchema
+        .effectiveBranch('cat')
+        .safeParseAs(
+          data,
+          (validated) => CatType(validated as Map<String, Object?>),
+        );
   }
 
   int get lives => _data['lives'] as int;
@@ -63,17 +67,21 @@ extension type DogType(Map<String, Object?> _data)
   String get type => _data['type'] as String;
 
   static DogType parse(Object? data) {
-    return dogSchema.parseAs(
-      data,
-      (validated) => DogType(validated as Map<String, Object?>),
-    );
+    return petSchema
+        .effectiveBranch('dog')
+        .parseAs(
+          data,
+          (validated) => DogType(validated as Map<String, Object?>),
+        );
   }
 
   static SchemaResult<DogType> safeParse(Object? data) {
-    return dogSchema.safeParseAs(
-      data,
-      (validated) => DogType(validated as Map<String, Object?>),
-    );
+    return petSchema
+        .effectiveBranch('dog')
+        .safeParseAs(
+          data,
+          (validated) => DogType(validated as Map<String, Object?>),
+        );
   }
 
   String get breed => _data['breed'] as String;

--- a/example/lib/schema_types_discriminated.dart
+++ b/example/lib/schema_types_discriminated.dart
@@ -5,16 +5,10 @@ part 'schema_types_discriminated.g.dart';
 
 /// Discriminated schema example for @AckType extension generation.
 @AckType()
-final catSchema = Ack.object({
-  'kind': Ack.literal('cat'),
-  'lives': Ack.integer(),
-});
+final catSchema = Ack.object({'lives': Ack.integer()});
 
 @AckType()
-ObjectSchema get dogSchema => Ack.object({
-  'kind': Ack.literal('dog'),
-  'bark': Ack.boolean(),
-}).passthrough();
+ObjectSchema get dogSchema => Ack.object({'bark': Ack.boolean()}).passthrough();
 
 @AckType()
 final petSchema = Ack.discriminated(

--- a/example/lib/schema_types_discriminated.g.dart
+++ b/example/lib/schema_types_discriminated.g.dart
@@ -41,17 +41,21 @@ extension type CatType(Map<String, Object?> _data)
   String get kind => _data['kind'] as String;
 
   static CatType parse(Object? data) {
-    return catSchema.parseAs(
-      data,
-      (validated) => CatType(validated as Map<String, Object?>),
-    );
+    return petSchema
+        .effectiveBranch('cat')
+        .parseAs(
+          data,
+          (validated) => CatType(validated as Map<String, Object?>),
+        );
   }
 
   static SchemaResult<CatType> safeParse(Object? data) {
-    return catSchema.safeParseAs(
-      data,
-      (validated) => CatType(validated as Map<String, Object?>),
-    );
+    return petSchema
+        .effectiveBranch('cat')
+        .safeParseAs(
+          data,
+          (validated) => CatType(validated as Map<String, Object?>),
+        );
   }
 
   int get lives => _data['lives'] as int;
@@ -63,17 +67,21 @@ extension type DogType(Map<String, Object?> _data)
   String get kind => _data['kind'] as String;
 
   static DogType parse(Object? data) {
-    return dogSchema.parseAs(
-      data,
-      (validated) => DogType(validated as Map<String, Object?>),
-    );
+    return petSchema
+        .effectiveBranch('dog')
+        .parseAs(
+          data,
+          (validated) => DogType(validated as Map<String, Object?>),
+        );
   }
 
   static SchemaResult<DogType> safeParse(Object? data) {
-    return dogSchema.safeParseAs(
-      data,
-      (validated) => DogType(validated as Map<String, Object?>),
-    );
+    return petSchema
+        .effectiveBranch('dog')
+        .safeParseAs(
+          data,
+          (validated) => DogType(validated as Map<String, Object?>),
+        );
   }
 
   bool get bark => _data['bark'] as bool;

--- a/example/test/schema_types_discriminated_test.dart
+++ b/example/test/schema_types_discriminated_test.dart
@@ -1,0 +1,48 @@
+import 'package:ack_example/pet.dart' as explicit;
+import 'package:ack_example/schema_types_discriminated.dart' as omitted;
+import 'package:test/test.dart';
+
+void main() {
+  group('discriminated generated types with omitted branch discriminators', () {
+    test('base parser returns the matching subtype', () {
+      final cat = omitted.PetType.parse({'kind': 'cat', 'lives': 9});
+      final dog = omitted.PetType.parse({'kind': 'dog', 'bark': true});
+
+      expect(cat, isA<omitted.CatType>());
+      expect(dog, isA<omitted.DogType>());
+    });
+
+    test('subtype parser rejects another valid union branch', () {
+      final result = omitted.CatType.safeParse({'kind': 'dog', 'bark': true});
+
+      expect(result.isFail, isTrue);
+      expect(
+        () => omitted.CatType.parse({'kind': 'dog', 'bark': true}),
+        throwsA(anything),
+      );
+    });
+  });
+
+  group('discriminated generated types with explicit branch literals', () {
+    test('base parser returns the matching subtype', () {
+      final cat = explicit.PetType.parse({'type': 'cat', 'lives': 9});
+      final dog = explicit.PetType.parse({'type': 'dog', 'breed': 'Poodle'});
+
+      expect(cat, isA<explicit.CatType>());
+      expect(dog, isA<explicit.DogType>());
+    });
+
+    test('subtype parser rejects another valid union branch', () {
+      final result = explicit.CatType.safeParse({
+        'type': 'dog',
+        'breed': 'Poodle',
+      });
+
+      expect(result.isFail, isTrue);
+      expect(
+        () => explicit.CatType.parse({'type': 'dog', 'breed': 'Poodle'}),
+        throwsA(anything),
+      );
+    });
+  });
+}

--- a/llms.txt
+++ b/llms.txt
@@ -98,8 +98,8 @@ Not supported for extension-type generation:
 - each branch is non-nullable
 - each branch is declared in the same library as the base
 - branch schemas normally omit the discriminator field
-- if a branch includes the discriminator field, it must be statically provable
-  that the field accepts the branch key
+- if a branch includes the discriminator field, it must be `Ack.literal(...)`
+  matching the branch key or `Ack.enumString(...)` containing the branch key
 
 Example:
 
@@ -127,7 +127,7 @@ final petSchema = Ack.discriminated(
 `Ack.discriminated(...)` owns the discriminator property. Boundary payloads
 must still include the discriminator key, but branch schemas should usually
 omit it. If a branch schema includes the discriminator field, it must be
-statically provable as compatible with the branch map key:
+an exact literal or enum containing the branch map key:
 
 ```dart
 @AckType()
@@ -138,9 +138,10 @@ final catSchema = Ack.object({
 ```
 
 Conflicting discriminator fields are rejected. Exported and generated schemas
-treat the discriminator as an exact literal for each branch, and generated
-subtype `parse()` / `safeParse()` methods validate through the union's
-effective branch.
+treat the discriminator as an exact literal for each branch. Broad
+`Ack.string()`, transformed/refined discriminator fields, and restrictive
+chains are rejected. Generated subtype `parse()` / `safeParse()` methods
+validate through the union's effective branch.
 
 ## Resolution rules
 

--- a/llms.txt
+++ b/llms.txt
@@ -97,21 +97,20 @@ Not supported for extension-type generation:
 - each branch is an `@AckType()` object schema
 - each branch is non-nullable
 - each branch is declared in the same library as the base
-- each branch defines the discriminator field with `Ack.literal(...)`
-- the literal value matches the branch key
+- branch schemas normally omit the discriminator field
+- if a branch includes the discriminator field, it must be statically provable
+  that the field accepts the branch key
 
 Example:
 
 ```dart
 @AckType()
 final catSchema = Ack.object({
-  'type': Ack.literal('cat'),
   'lives': Ack.integer(),
 });
 
 @AckType()
 final dogSchema = Ack.object({
-  'type': Ack.literal('dog'),
   'breed': Ack.string(),
 });
 
@@ -124,6 +123,24 @@ final petSchema = Ack.discriminated(
   },
 );
 ```
+
+`Ack.discriminated(...)` owns the discriminator property. Boundary payloads
+must still include the discriminator key, but branch schemas should usually
+omit it. If a branch schema includes the discriminator field, it must be
+statically provable as compatible with the branch map key:
+
+```dart
+@AckType()
+final catSchema = Ack.object({
+  'type': Ack.literal('cat'), // allowed, but usually unnecessary
+  'lives': Ack.integer(),
+});
+```
+
+Conflicting discriminator fields are rejected. Exported and generated schemas
+treat the discriminator as an exact literal for each branch, and generated
+subtype `parse()` / `safeParse()` methods validate through the union's
+effective branch.
 
 ## Resolution rules
 

--- a/packages/ack/lib/src/converters/ack_to_json_schema_model.dart
+++ b/packages/ack/lib/src/converters/ack_to_json_schema_model.dart
@@ -205,32 +205,32 @@ JsonSchema _discriminated(
   for (final entry in schema.schemas.entries) {
     final label = entry.key;
     final originalBranchSchema = entry.value;
-    final baseBranchSchema = unwrapDiscriminatedBranchSchema(
-      originalBranchSchema,
+    final effectiveBranchSchema = effectiveDiscriminatedBranch(
+      discriminatorKey: discriminatorKey,
+      discriminatorValue: label,
+      branchSchema: originalBranchSchema,
     );
-    if (baseBranchSchema is! ObjectSchema) {
-      throw ArgumentError(
-        'Discriminated branches must be object-backed schemas.',
-      );
-    }
 
-    if (baseBranchSchema.properties.containsKey(discriminatorKey)) {
-      throw ArgumentError(
-        'Discriminator key "$discriminatorKey" conflicts with existing property in branch "$label".',
-      );
-    }
-
-    final convertedBranch = _convert(originalBranchSchema);
+    final convertedBranch = _convert(effectiveBranchSchema);
     final properties = <String, JsonSchema>{
-      ...?convertedBranch.properties,
       discriminatorKey: JsonSchema(
         type: JsonSchemaType.string,
         enumValues: [label],
       ),
+      for (final entry
+          in convertedBranch.properties?.entries ??
+              <MapEntry<String, JsonSchema>>[])
+        if (entry.key != discriminatorKey) entry.key: entry.value,
     };
     final required = <String>[
       discriminatorKey,
       ...?convertedBranch.required?.where((field) => field != discriminatorKey),
+    ];
+    final propertyOrdering = <String>[
+      discriminatorKey,
+      ...?convertedBranch.propertyOrdering?.where(
+        (field) => field != discriminatorKey,
+      ),
     ];
 
     branches.add(
@@ -238,6 +238,7 @@ JsonSchema _discriminated(
         type: JsonSchemaType.object,
         properties: properties,
         required: required,
+        propertyOrdering: propertyOrdering,
       ),
     );
   }

--- a/packages/ack/lib/src/schemas/discriminated_object_schema.dart
+++ b/packages/ack/lib/src/schemas/discriminated_object_schema.dart
@@ -24,11 +24,9 @@ Object? _serializeJsonSchemaDefaultOrNull(Object? defaultValue) {
 ///   discriminatorKey: 'type',
 ///   schemas: {
 ///     'cat': Ack.object({
-///       'type': Ack.literal('cat'),
 ///       'name': Ack.string(),
 ///     }).transform<Animal>((map) => Cat(map['name'] as String)),
 ///     'dog': Ack.object({
-///       'type': Ack.literal('dog'),
 ///       'name': Ack.string(),
 ///     }).transform<Animal>((map) => Dog(map['name'] as String)),
 ///   },
@@ -50,6 +48,27 @@ final class DiscriminatedObjectSchema<T extends Object> extends AckSchema<T>
     super.constraints,
     super.refinements,
   });
+
+  /// Returns the effective schema for [discriminatorValue].
+  ///
+  /// The effective schema includes this union's discriminator property as an
+  /// exact branch literal, even when the authored branch omitted it.
+  AckSchema<T> effectiveBranch(String discriminatorValue) {
+    final branchSchema = schemas[discriminatorValue];
+    if (branchSchema == null) {
+      throw ArgumentError.value(
+        discriminatorValue,
+        'discriminatorValue',
+        'No discriminated branch is registered for this value.',
+      );
+    }
+
+    return effectiveDiscriminatedBranch<T>(
+      discriminatorKey: discriminatorKey,
+      discriminatorValue: discriminatorValue,
+      branchSchema: branchSchema,
+    );
+  }
 
   @override
   SchemaType get schemaType => SchemaType.discriminated;
@@ -160,24 +179,33 @@ final class DiscriminatedObjectSchema<T extends Object> extends AckSchema<T>
     }
 
     // Validate the selected branch; branch name for debug only
-    final subSchemaContext = context.createChild(
+    var subSchemaContext = context.createChild(
       name: 'when $discriminatorKey="$discValueRaw"',
       schema: selectedSubSchema,
       value: mapValue,
       pathSegment: '', // Inherit parent path
     );
 
-    final baseSubSchema = unwrapDiscriminatedBranchSchema(selectedSubSchema);
-    if (baseSubSchema is! ObjectSchema) {
+    final AckSchema<T> effectiveSubSchema;
+    try {
+      effectiveSubSchema = effectiveBranch(discValueRaw);
+    } on ArgumentError catch (error) {
       return SchemaResult.fail(
         SchemaValidationError(
-          message: 'Discriminated branches must be object-backed schemas',
+          message: error.message?.toString() ?? error.toString(),
           context: subSchemaContext,
         ),
       );
     }
 
-    final result = selectedSubSchema.parseAndValidate(
+    subSchemaContext = context.createChild(
+      name: 'when $discriminatorKey="$discValueRaw"',
+      schema: effectiveSubSchema,
+      value: mapValue,
+      pathSegment: '', // Inherit parent path
+    );
+
+    final result = effectiveSubSchema.parseAndValidate(
       mapValue,
       subSchemaContext,
     );
@@ -221,19 +249,8 @@ final class DiscriminatedObjectSchema<T extends Object> extends AckSchema<T>
   Map<String, Object?> toJsonSchema() {
     final anyOfClauses = <Map<String, Object?>>[];
     final serializedDefault = _serializeJsonSchemaDefaultOrNull(defaultValue);
-    schemas.forEach((discriminatorValue, branchSchema) {
-      final baseSchema = unwrapDiscriminatedBranchSchema(branchSchema);
-      if (baseSchema is! ObjectSchema) {
-        throw ArgumentError(
-          'Discriminated branches must be object-backed schemas.',
-        );
-      }
-      final subSchemaJson = branchSchema.toJsonSchema();
-      // Constrain discriminator property with type and const
-      subSchemaJson['properties'] = {
-        ...?(subSchemaJson['properties'] as Map?),
-        discriminatorKey: {'type': 'string', 'const': discriminatorValue},
-      };
+    schemas.forEach((discriminatorValue, _) {
+      final subSchemaJson = effectiveBranch(discriminatorValue).toJsonSchema();
       // Build required array with discriminator first
       final existingRequired =
           (subSchemaJson['required'] as List?)?.cast<String>() ?? <String>[];

--- a/packages/ack/lib/src/schemas/transformed_schema.dart
+++ b/packages/ack/lib/src/schemas/transformed_schema.dart
@@ -131,6 +131,22 @@ class TransformedSchema<InputType extends Object, OutputType extends Object>
     );
   }
 
+  /// Returns a copy of this transformed schema with a different input schema.
+  TransformedSchema<InputType, OutputType> copyWithSchema(
+    AckSchema<InputType> schema,
+  ) {
+    return TransformedSchema(
+      schema,
+      transformer,
+      isNullable: isNullable,
+      isOptional: isOptional,
+      description: description,
+      defaultValue: defaultValue,
+      constraints: constraints,
+      refinements: refinements,
+    );
+  }
+
   @override
   Map<String, Object?> toJsonSchema() {
     // A transformed schema doesn't have a direct, standard JSON Schema representation.

--- a/packages/ack/lib/src/utils/discriminated_branch_utils.dart
+++ b/packages/ack/lib/src/utils/discriminated_branch_utils.dart
@@ -1,14 +1,90 @@
+import '../constraints/string_literal_constraint.dart';
 import '../schemas/schema.dart';
 
-/// Returns the underlying branch schema by unwrapping any transform layers.
+StringSchema _discriminatorLiteralSchema(String discriminatorValue) {
+  return StringSchema(
+    constraints: [StringLiteralConstraint(discriminatorValue)],
+  );
+}
+
+/// Returns whether [propertySchema] accepts [discriminatorValue].
+bool discriminatorPropertyAcceptsValue({
+  required AckSchema propertySchema,
+  required String discriminatorValue,
+}) {
+  return propertySchema.safeParse(discriminatorValue).isOk;
+}
+
+/// Builds the effective object branch for a discriminated-union value.
 ///
-/// Discriminated branches may be wrapped in [TransformedSchema] while still
-/// being object-backed at their core.
-AckSchema unwrapDiscriminatedBranchSchema(AckSchema schema) {
-  var current = schema;
-  while (current is TransformedSchema) {
-    current = current.schema;
+/// The returned object schema always contains [discriminatorKey] first, as an
+/// exact string literal matching [discriminatorValue]. The authored schema is
+/// never mutated.
+ObjectSchema effectiveDiscriminatedObjectBranch({
+  required String discriminatorKey,
+  required String discriminatorValue,
+  required ObjectSchema objectSchema,
+}) {
+  final existingDiscriminator = objectSchema.properties[discriminatorKey];
+  if (existingDiscriminator != null &&
+      !discriminatorPropertyAcceptsValue(
+        propertySchema: existingDiscriminator,
+        discriminatorValue: discriminatorValue,
+      )) {
+    throw ArgumentError(
+      'Discriminator property "$discriminatorKey" does not accept '
+      'branch value "$discriminatorValue".',
+    );
   }
 
-  return current;
+  final properties = <String, AckSchema>{
+    discriminatorKey: _discriminatorLiteralSchema(discriminatorValue),
+    for (final entry in objectSchema.properties.entries)
+      if (entry.key != discriminatorKey) entry.key: entry.value,
+  };
+
+  return objectSchema.copyWith(properties: properties);
+}
+
+/// Builds the effective schema for a discriminated-union branch.
+///
+/// Supports plain object branches and direct object-backed transforms. The
+/// effective schema validates/exports as if the branch owned a literal
+/// discriminator, while preserving the branch output type.
+AckSchema<T> effectiveDiscriminatedBranch<T extends Object>({
+  required String discriminatorKey,
+  required String discriminatorValue,
+  required AckSchema<T> branchSchema,
+}) {
+  return _effectiveDiscriminatedBranch(
+        discriminatorKey: discriminatorKey,
+        discriminatorValue: discriminatorValue,
+        branchSchema: branchSchema,
+      )
+      as AckSchema<T>;
+}
+
+AckSchema _effectiveDiscriminatedBranch({
+  required String discriminatorKey,
+  required String discriminatorValue,
+  required AckSchema branchSchema,
+}) {
+  if (branchSchema is ObjectSchema) {
+    return effectiveDiscriminatedObjectBranch(
+      discriminatorKey: discriminatorKey,
+      discriminatorValue: discriminatorValue,
+      objectSchema: branchSchema,
+    );
+  }
+
+  if (branchSchema is TransformedSchema<Object, Object>) {
+    final effectiveInputSchema = _effectiveDiscriminatedBranch(
+      discriminatorKey: discriminatorKey,
+      discriminatorValue: discriminatorValue,
+      branchSchema: branchSchema.schema,
+    );
+    return branchSchema.copyWithSchema(effectiveInputSchema);
+  }
+
+  throw ArgumentError('Discriminated branches must be object-backed schemas');
 }

--- a/packages/ack/lib/src/utils/discriminated_branch_utils.dart
+++ b/packages/ack/lib/src/utils/discriminated_branch_utils.dart
@@ -1,3 +1,4 @@
+import '../constraints/pattern_constraint.dart';
 import '../constraints/string_literal_constraint.dart';
 import '../schemas/schema.dart';
 
@@ -8,11 +9,29 @@ StringSchema _discriminatorLiteralSchema(String discriminatorValue) {
 }
 
 /// Returns whether [propertySchema] accepts [discriminatorValue].
+///
+/// This compatibility check is structural and side-effect-free. It deliberately
+/// does not parse the discriminator value because parsing can execute user
+/// transforms/refinements during branch selection or schema export.
 bool discriminatorPropertyAcceptsValue({
   required AckSchema propertySchema,
   required String discriminatorValue,
 }) {
-  return propertySchema.safeParse(discriminatorValue).isOk;
+  if (propertySchema is! StringSchema) return false;
+  if (propertySchema.refinements.isNotEmpty) return false;
+  if (propertySchema.constraints.length != 1) return false;
+
+  final constraint = propertySchema.constraints.single;
+  if (constraint is StringLiteralConstraint) {
+    return constraint.expectedValue == discriminatorValue;
+  }
+
+  if (constraint is PatternConstraint &&
+      constraint.type == PatternType.enumString) {
+    return constraint.allowedValues?.contains(discriminatorValue) ?? false;
+  }
+
+  return false;
 }
 
 /// Builds the effective object branch for a discriminated-union value.

--- a/packages/ack/test/converters/ack_to_json_schema_model_test.dart
+++ b/packages/ack/test/converters/ack_to_json_schema_model_test.dart
@@ -115,7 +115,10 @@ void main() {
           discriminatorKey: 'type',
           schemas: {
             'cat': Ack.object({'lives': Ack.integer()}),
-            'dog': Ack.object({'type': Ack.string(), 'breed': Ack.string()}),
+            'dog': Ack.object({
+              'type': Ack.enumString(['dog', 'canine']),
+              'breed': Ack.string(),
+            }),
           },
         );
 
@@ -139,6 +142,17 @@ void main() {
         expect(dogBranch.propertyOrdering, equals(['type', 'breed']));
       },
     );
+
+    test('toJsonSchemaModel_rejects_broad_string_discriminator_property', () {
+      final schema = Ack.discriminated(
+        discriminatorKey: 'type',
+        schemas: {
+          'cat': Ack.object({'type': Ack.string(), 'lives': Ack.integer()}),
+        },
+      );
+
+      expect(() => schema.toJsonSchemaModel(), throwsArgumentError);
+    });
 
     test(
       'preserves transformed branch description in discriminated model conversion',

--- a/packages/ack/test/converters/ack_to_json_schema_model_test.dart
+++ b/packages/ack/test/converters/ack_to_json_schema_model_test.dart
@@ -109,6 +109,38 @@ void main() {
     });
 
     test(
+      'toJsonSchemaModel_accepts_omitted_and_compatible_existing_discriminator_property',
+      () {
+        final schema = Ack.discriminated(
+          discriminatorKey: 'type',
+          schemas: {
+            'cat': Ack.object({'lives': Ack.integer()}),
+            'dog': Ack.object({'type': Ack.string(), 'breed': Ack.string()}),
+          },
+        );
+
+        final json = schema.toJsonSchemaModel();
+
+        expect(json.discriminator?.propertyName, equals('type'));
+        expect(json.oneOf, hasLength(2));
+
+        final catBranch = json.oneOf!.firstWhere(
+          (branch) =>
+              branch.properties?['type']?.enumValues?.contains('cat') ?? false,
+        );
+        expect(catBranch.required, equals(['type', 'lives']));
+        expect(catBranch.propertyOrdering, equals(['type', 'lives']));
+
+        final dogBranch = json.oneOf!.firstWhere(
+          (branch) =>
+              branch.properties?['type']?.enumValues?.contains('dog') ?? false,
+        );
+        expect(dogBranch.required, equals(['type', 'breed']));
+        expect(dogBranch.propertyOrdering, equals(['type', 'breed']));
+      },
+    );
+
+    test(
       'preserves transformed branch description in discriminated model conversion',
       () {
         final schema = Ack.discriminated<String>(

--- a/packages/ack/test/schemas/composite_default_test.dart
+++ b/packages/ack/test/schemas/composite_default_test.dart
@@ -270,11 +270,8 @@ void main() {
         final schema = Ack.discriminated(
           discriminatorKey: 'type',
           schemas: {
-            'circle': Ack.object({
-              'type': Ack.string(),
-              'radius': Ack.integer(),
-            }),
-            'square': Ack.object({'type': Ack.string(), 'side': Ack.integer()}),
+            'circle': Ack.object({'radius': Ack.integer()}),
+            'square': Ack.object({'side': Ack.integer()}),
           },
         ).copyWith(defaultValue: defaultValue);
 
@@ -290,11 +287,8 @@ void main() {
         final schema = Ack.discriminated(
           discriminatorKey: 'type',
           schemas: {
-            'circle': Ack.object({
-              'type': Ack.string(),
-              'radius': Ack.integer(),
-            }),
-            'square': Ack.object({'type': Ack.string(), 'side': Ack.integer()}),
+            'circle': Ack.object({'radius': Ack.integer()}),
+            'square': Ack.object({'side': Ack.integer()}),
           },
         ).copyWith(defaultValue: defaultValue);
 
@@ -311,10 +305,7 @@ void main() {
         final schema = Ack.discriminated(
           discriminatorKey: 'type',
           schemas: {
-            'circle': Ack.object({
-              'type': Ack.string(),
-              'radius': Ack.integer(),
-            }),
+            'circle': Ack.object({'radius': Ack.integer()}),
           },
         ).copyWith(defaultValue: defaultValue);
 
@@ -336,11 +327,8 @@ void main() {
         final schema = Ack.discriminated(
           discriminatorKey: 'type',
           schemas: {
-            'circle': Ack.object({
-              'type': Ack.string(),
-              'radius': Ack.integer(),
-            }),
-            'square': Ack.object({'type': Ack.string(), 'side': Ack.integer()}),
+            'circle': Ack.object({'radius': Ack.integer()}),
+            'square': Ack.object({'side': Ack.integer()}),
           },
         ).copyWith(defaultValue: defaultValue);
 
@@ -357,10 +345,7 @@ void main() {
         final schema = Ack.discriminated(
           discriminatorKey: 'type',
           schemas: {
-            'circle': Ack.object({
-              'type': Ack.string(),
-              'radius': Ack.integer(),
-            }),
+            'circle': Ack.object({'radius': Ack.integer()}),
           },
         ).copyWith(defaultValue: defaultValue);
 

--- a/packages/ack/test/schemas/comprehensive_json_schema_test.dart
+++ b/packages/ack/test/schemas/comprehensive_json_schema_test.dart
@@ -450,13 +450,11 @@ void main() {
 
         setUp(() {
           carSchema = Ack.object({
-            'type': Ack.string(),
             'doors': Ack.integer(),
             'engine': Ack.string(),
           });
 
           bikeSchema = Ack.object({
-            'type': Ack.string(),
             'wheels': Ack.integer(),
             'pedals': Ack.boolean(),
           });
@@ -682,15 +680,11 @@ void main() {
             discriminatorKey: 'type',
             schemas: {
               'credit_card': Ack.object({
-                'type': Ack.string(),
                 'cardNumber': Ack.string().length(16),
                 'expiryMonth': Ack.integer().min(1).max(12),
                 'expiryYear': Ack.integer().min(2023),
               }),
-              'paypal': Ack.object({
-                'type': Ack.string(),
-                'email': Ack.string().email(),
-              }),
+              'paypal': Ack.object({'email': Ack.string().email()}),
             },
           ),
         });

--- a/packages/ack/test/schemas/discriminated_object_schema_test.dart
+++ b/packages/ack/test/schemas/discriminated_object_schema_test.dart
@@ -10,9 +10,9 @@ void main() {
     late DiscriminatedObjectSchema animalSchema;
 
     setUp(() {
-      catSchema = Ack.object({'type': Ack.string(), 'meow': Ack.boolean()});
+      catSchema = Ack.object({'meow': Ack.boolean()});
 
-      dogSchema = Ack.object({'type': Ack.string(), 'bark': Ack.boolean()});
+      dogSchema = Ack.object({'bark': Ack.boolean()});
 
       animalSchema = Ack.discriminated(
         discriminatorKey: 'type',
@@ -99,8 +99,29 @@ void main() {
         expect(result.isOk, isTrue);
       });
 
+      test('branch_with_matching_enum_discriminator_parses_and_exports', () {
+        final cat = Ack.object({
+          'type': Ack.enumString(['cat', 'kitty']),
+          'lives': Ack.integer(),
+        });
+        final pet = Ack.discriminated(
+          discriminatorKey: 'type',
+          schemas: {'cat': cat},
+        );
+
+        final result = pet.safeParse({'type': 'cat', 'lives': 9});
+        final jsonSchema = pet.toJsonSchema();
+        final branch = ((jsonSchema['anyOf'] as List<Object?>).single as Map)
+            .cast<String, Object?>();
+        final properties = (branch['properties'] as Map)
+            .cast<String, Object?>();
+
+        expect(result.isOk, isTrue);
+        expect(properties['type'], equals({'type': 'string', 'const': 'cat'}));
+      });
+
       test(
-        'branch_with_broad_string_discriminator_parses_and_exports_literal',
+        'branch_with_broad_string_discriminator_fails_and_export_rejects',
         () {
           final cat = Ack.object({
             'type': Ack.string(),
@@ -112,19 +133,62 @@ void main() {
           );
 
           final result = pet.safeParse({'type': 'cat', 'lives': 9});
-          final jsonSchema = pet.toJsonSchema();
-          final branch = ((jsonSchema['anyOf'] as List<Object?>).single as Map)
-              .cast<String, Object?>();
-          final properties = (branch['properties'] as Map)
-              .cast<String, Object?>();
 
-          expect(result.isOk, isTrue);
-          expect(
-            properties['type'],
-            equals({'type': 'string', 'const': 'cat'}),
-          );
+          expect(result.isOk, isFalse);
+          expect(() => pet.toJsonSchema(), throwsArgumentError);
         },
       );
+
+      test(
+        'transform_discriminator_compatibility_check_is_side_effect_free',
+        () {
+          var transformCalled = false;
+          final cat = Ack.object({
+            'type': Ack.string().transform<String>((value) {
+              transformCalled = true;
+              return value;
+            }),
+            'lives': Ack.integer(),
+          });
+          final pet = Ack.discriminated(
+            discriminatorKey: 'type',
+            schemas: {'cat': cat},
+          );
+
+          final result = pet.safeParse({'type': 'cat', 'lives': 9});
+
+          expect(result.isOk, isFalse);
+          expect(transformCalled, isFalse);
+          expect(() => pet.effectiveBranch('cat'), throwsArgumentError);
+          expect(transformCalled, isFalse);
+          expect(() => pet.toJsonSchema(), throwsArgumentError);
+          expect(transformCalled, isFalse);
+        },
+      );
+
+      test('refine_discriminator_compatibility_check_is_side_effect_free', () {
+        var refineCalled = false;
+        final cat = Ack.object({
+          'type': Ack.string().refine((value) {
+            refineCalled = true;
+            return true;
+          }),
+          'lives': Ack.integer(),
+        });
+        final pet = Ack.discriminated(
+          discriminatorKey: 'type',
+          schemas: {'cat': cat},
+        );
+
+        final result = pet.safeParse({'type': 'cat', 'lives': 9});
+
+        expect(result.isOk, isFalse);
+        expect(refineCalled, isFalse);
+        expect(() => pet.effectiveBranch('cat'), throwsArgumentError);
+        expect(refineCalled, isFalse);
+        expect(() => pet.toJsonSchema(), throwsArgumentError);
+        expect(refineCalled, isFalse);
+      });
 
       test('branch_with_conflicting_literal_discriminator_fails', () {
         final cat = Ack.object({
@@ -139,6 +203,22 @@ void main() {
         final result = pet.safeParse({'type': 'cat', 'lives': 9});
 
         expect(result.isOk, isFalse);
+      });
+
+      test('branch_with_restrictive_discriminator_chain_fails', () {
+        final cat = Ack.object({
+          'type': Ack.literal('cat').minLength(4),
+          'lives': Ack.integer(),
+        });
+        final pet = Ack.discriminated(
+          discriminatorKey: 'type',
+          schemas: {'cat': cat},
+        );
+
+        final result = pet.safeParse({'type': 'cat', 'lives': 9});
+
+        expect(result.isOk, isFalse);
+        expect(() => pet.toJsonSchema(), throwsArgumentError);
       });
 
       test(
@@ -290,10 +370,7 @@ void main() {
       );
 
       test('copyWith updates specific values', () {
-        final birdSchema = Ack.object({
-          'type': Ack.string(),
-          'fly': Ack.boolean(),
-        });
+        final birdSchema = Ack.object({'fly': Ack.boolean()});
 
         final newSchemas = {
           'cat': catSchema,

--- a/packages/ack/test/schemas/discriminated_object_schema_test.dart
+++ b/packages/ack/test/schemas/discriminated_object_schema_test.dart
@@ -52,6 +52,185 @@ void main() {
       });
     });
 
+    group('Union-owned discriminator policy', () {
+      test(
+        'branch_without_discriminator_parses_when_union_input_has_discriminator',
+        () {
+          final cat = Ack.object({'lives': Ack.integer()});
+          final pet = Ack.discriminated(
+            discriminatorKey: 'type',
+            schemas: {'cat': cat},
+          );
+
+          final result = pet.safeParse({'type': 'cat', 'lives': 9});
+
+          expect(result.isOk, isTrue);
+          expect(result.getOrThrow(), equals({'type': 'cat', 'lives': 9}));
+        },
+      );
+
+      test(
+        'branch_without_discriminator_rejects_missing_discriminator_on_union_input',
+        () {
+          final cat = Ack.object({'lives': Ack.integer()});
+          final pet = Ack.discriminated(
+            discriminatorKey: 'type',
+            schemas: {'cat': cat},
+          );
+
+          final result = pet.safeParse({'lives': 9});
+
+          expect(result.isOk, isFalse);
+        },
+      );
+
+      test('branch_with_matching_literal_discriminator_parses', () {
+        final cat = Ack.object({
+          'type': Ack.literal('cat'),
+          'lives': Ack.integer(),
+        });
+        final pet = Ack.discriminated(
+          discriminatorKey: 'type',
+          schemas: {'cat': cat},
+        );
+
+        final result = pet.safeParse({'type': 'cat', 'lives': 9});
+
+        expect(result.isOk, isTrue);
+      });
+
+      test(
+        'branch_with_broad_string_discriminator_parses_and_exports_literal',
+        () {
+          final cat = Ack.object({
+            'type': Ack.string(),
+            'lives': Ack.integer(),
+          });
+          final pet = Ack.discriminated(
+            discriminatorKey: 'type',
+            schemas: {'cat': cat},
+          );
+
+          final result = pet.safeParse({'type': 'cat', 'lives': 9});
+          final jsonSchema = pet.toJsonSchema();
+          final branch = ((jsonSchema['anyOf'] as List<Object?>).single as Map)
+              .cast<String, Object?>();
+          final properties = (branch['properties'] as Map)
+              .cast<String, Object?>();
+
+          expect(result.isOk, isTrue);
+          expect(
+            properties['type'],
+            equals({'type': 'string', 'const': 'cat'}),
+          );
+        },
+      );
+
+      test('branch_with_conflicting_literal_discriminator_fails', () {
+        final cat = Ack.object({
+          'type': Ack.literal('dog'),
+          'lives': Ack.integer(),
+        });
+        final pet = Ack.discriminated(
+          discriminatorKey: 'type',
+          schemas: {'cat': cat},
+        );
+
+        final result = pet.safeParse({'type': 'cat', 'lives': 9});
+
+        expect(result.isOk, isFalse);
+      });
+
+      test(
+        'toJsonSchema_injects_required_literal_discriminator_for_omitted_branch_property',
+        () {
+          final cat = Ack.object({'lives': Ack.integer()});
+          final pet = Ack.discriminated(
+            discriminatorKey: 'type',
+            schemas: {'cat': cat},
+          );
+
+          final jsonSchema = pet.toJsonSchema();
+          final branch = ((jsonSchema['anyOf'] as List<Object?>).single as Map)
+              .cast<String, Object?>();
+          final properties = (branch['properties'] as Map)
+              .cast<String, Object?>();
+
+          expect(
+            properties['type'],
+            equals({'type': 'string', 'const': 'cat'}),
+          );
+          expect(branch['required'], equals(['type', 'lives']));
+        },
+      );
+
+      test(
+        'toJsonSchema_preserves_branch_properties_and_adds_discriminator_first',
+        () {
+          final cat = Ack.object({
+            'lives': Ack.integer(),
+            'name': Ack.string(),
+          });
+          final pet = Ack.discriminated(
+            discriminatorKey: 'type',
+            schemas: {'cat': cat},
+          );
+
+          final jsonSchema = pet.toJsonSchema();
+          final branch = ((jsonSchema['anyOf'] as List<Object?>).single as Map)
+              .cast<String, Object?>();
+          final properties = (branch['properties'] as Map)
+              .cast<String, Object?>();
+
+          expect(properties.keys.toList(), equals(['type', 'lives', 'name']));
+          expect(branch['required'], equals(['type', 'lives', 'name']));
+        },
+      );
+
+      test(
+        'effective_branch_injection_does_not_mutate_original_branch_schema',
+        () {
+          final cat = Ack.object({'lives': Ack.integer()});
+          final pet = Ack.discriminated(
+            discriminatorKey: 'type',
+            schemas: {'cat': cat},
+          );
+
+          final result = pet.safeParse({'type': 'cat', 'lives': 9});
+
+          expect(result.isOk, isTrue);
+          expect(cat.properties, isNot(contains('type')));
+        },
+      );
+
+      test('effectiveBranch validates a specific branch schema', () {
+        final cat = Ack.object({'lives': Ack.integer()});
+        final dog = Ack.object({'breed': Ack.string()});
+        final pet = Ack.discriminated(
+          discriminatorKey: 'type',
+          schemas: {'cat': cat, 'dog': dog},
+        );
+
+        final catBranch = pet.effectiveBranch('cat');
+
+        expect(catBranch.safeParse({'type': 'cat', 'lives': 9}).isOk, isTrue);
+        expect(
+          catBranch.safeParse({'type': 'dog', 'breed': 'Poodle'}).isFail,
+          isTrue,
+        );
+      });
+
+      test('effectiveBranch rejects unknown discriminator values', () {
+        final cat = Ack.object({'lives': Ack.integer()});
+        final pet = Ack.discriminated(
+          discriminatorKey: 'type',
+          schemas: {'cat': cat},
+        );
+
+        expect(() => pet.effectiveBranch('dog'), throwsArgumentError);
+      });
+    });
+
     group('Fluent methods', () {
       test('nullable() creates nullable schema', () {
         final nullableSchema = animalSchema.nullable();

--- a/packages/ack/test/schemas/json_schema_default_emission_test.dart
+++ b/packages/ack/test/schemas/json_schema_default_emission_test.dart
@@ -60,9 +60,7 @@ void main() {
       // DiscriminatedObjectSchema
       final disc = Ack.discriminated(
         discriminatorKey: 'type',
-        schemas: {
-          'a': Ack.object({'type': Ack.string()}),
-        },
+        schemas: {'a': Ack.object({})},
       );
       final discJsonSchema = disc.toJsonSchema();
       expect(

--- a/packages/ack/test/schemas/parse_result_immutability_test.dart
+++ b/packages/ack/test/schemas/parse_result_immutability_test.dart
@@ -106,7 +106,7 @@ void main() {
         final schema = Ack.discriminated(
           discriminatorKey: 'type',
           schemas: {
-            'cat': Ack.object({'type': Ack.string(), 'name': Ack.string()}),
+            'cat': Ack.object({'name': Ack.string()}),
           },
         );
 

--- a/packages/ack_firebase_ai/test/to_firebase_ai_schema_test.dart
+++ b/packages/ack_firebase_ai/test/to_firebase_ai_schema_test.dart
@@ -748,12 +748,12 @@ void main() {
     });
 
     group('DiscriminatedObjectSchema conversion', () {
-      test('throws when branch property conflicts with discriminator key', () {
+      test('throws when branch discriminator rejects branch key', () {
         final schema = Ack.discriminated(
           discriminatorKey: 'type',
           schemas: {
             'circle': Ack.object({
-              'type': Ack.string(), // conflict
+              'type': Ack.literal('square'),
               'radius': Ack.double(),
             }),
           },
@@ -800,6 +800,28 @@ void main() {
         expect(rectangleBranch.properties!['width'], isNotNull);
         expect(rectangleBranch.properties!['height'], isNotNull);
       });
+
+      test(
+        'converts discriminated schema with compatible existing discriminator property',
+        () {
+          final schema = Ack.discriminated(
+            discriminatorKey: 'type',
+            schemas: {
+              'circle': Ack.object({
+                'type': Ack.string(),
+                'radius': Ack.double(),
+              }),
+            },
+          );
+
+          final result = schema.toFirebaseAiSchema();
+          final circleBranch = result.anyOf!.single;
+
+          expect(circleBranch.properties!['type']!.enumValues, ['circle']);
+          expect(circleBranch.optionalProperties, isNot(contains('type')));
+          expect(circleBranch.properties!['radius'], isNotNull);
+        },
+      );
 
       test('handles empty discriminated schema', () {
         final schema = Ack.discriminated(

--- a/packages/ack_firebase_ai/test/to_firebase_ai_schema_test.dart
+++ b/packages/ack_firebase_ai/test/to_firebase_ai_schema_test.dart
@@ -808,7 +808,7 @@ void main() {
             discriminatorKey: 'type',
             schemas: {
               'circle': Ack.object({
-                'type': Ack.string(),
+                'type': Ack.enumString(['circle', 'round']),
                 'radius': Ack.double(),
               }),
             },

--- a/packages/ack_generator/README.md
+++ b/packages/ack_generator/README.md
@@ -56,16 +56,27 @@ dev_dependencies:
 ## Supported schema shapes
 
 - `Ack.object(...)`
-- Primitive schemas such as `Ack.string()`, `Ack.integer()`, `Ack.double()`, `Ack.boolean()`
+- Primitive schemas such as `Ack.string()`, `Ack.integer()`, `Ack.double()`,
+  `Ack.boolean()`
 - `Ack.list(...)` and `Set`-like list wrappers
 - `Ack.literal(...)`, `Ack.enumString(...)`, `Ack.enumValues(...)`
 - Non-object transforms with explicit output types
-- `Ack.discriminated(...)` when branches are top-level `@AckType` object schemas in the same library
+- `Ack.discriminated(...)` when branches are top-level `@AckType` object
+  schemas in the same library
+
+For discriminated unions, `Ack.discriminated(...)` owns the discriminator
+property. Branch schemas normally omit the discriminator field; if they include
+it, that field must be statically provable as accepting the branch map key.
+Boundary payloads must still include the discriminator key. Conflicting
+discriminator fields are rejected. Generated branches expose the exact branch
+literal, and generated subtype `parse()` / `safeParse()` methods validate
+through the union's effective branch.
 
 ## Important limitations
 
 - `Ack.any()` and `Ack.anyOf()` do not generate extension types.
-- Inline anonymous object branches are rejected for typed generation. Extract them to a named top-level schema first.
+- Inline anonymous object branches are rejected for typed generation. Extract
+  them to a named top-level schema first.
 - Nullable top-level schemas do not emit extension types.
 - `@AckType()` requires static schema resolution for nested object references.
 

--- a/packages/ack_generator/README.md
+++ b/packages/ack_generator/README.md
@@ -66,11 +66,12 @@ dev_dependencies:
 
 For discriminated unions, `Ack.discriminated(...)` owns the discriminator
 property. Branch schemas normally omit the discriminator field; if they include
-it, that field must be statically provable as accepting the branch map key.
-Boundary payloads must still include the discriminator key. Conflicting
-discriminator fields are rejected. Generated branches expose the exact branch
-literal, and generated subtype `parse()` / `safeParse()` methods validate
-through the union's effective branch.
+it, that field must be `Ack.literal(...)` matching the branch key or
+`Ack.enumString(...)` containing the branch key. Boundary payloads must still
+include the discriminator key. Conflicting, broad, transformed/refined, and
+restrictive discriminator fields are rejected. Generated branches expose the
+exact branch literal, and generated subtype `parse()` / `safeParse()` methods
+validate through the union's effective branch.
 
 ## Important limitations
 

--- a/packages/ack_generator/lib/src/analyzer/schema_ast_analyzer.dart
+++ b/packages/ack_generator/lib/src/analyzer/schema_ast_analyzer.dart
@@ -986,6 +986,14 @@ class SchemaAstAnalyzer {
 
       final schemaMethod = baseInvocation.methodName.name;
       if (schemaMethod == 'literal') {
+        if (!_hasOnlyNonRestrictiveDiscriminatorMethods(
+          expression,
+          baseInvocation,
+          baseMethod: 'literal',
+        )) {
+          return 'has discriminator property schema ${expression.toSource()} that could not be proven to accept "$discriminatorValue".';
+        }
+
         final literalValue = _extractSingleStringArgument(baseInvocation);
         if (literalValue == null) {
           return 'has a discriminator literal that is not a string literal.';
@@ -997,6 +1005,14 @@ class SchemaAstAnalyzer {
       }
 
       if (schemaMethod == 'enumString') {
+        if (!_hasOnlyNonRestrictiveDiscriminatorMethods(
+          expression,
+          baseInvocation,
+          baseMethod: 'enumString',
+        )) {
+          return 'has discriminator property schema ${expression.toSource()} that could not be proven to accept "$discriminatorValue".';
+        }
+
         final allowedValues = _extractStringListArgument(baseInvocation);
         if (allowedValues == null) {
           return 'has an Ack.enumString(...) discriminator that is not a string list literal.';
@@ -1009,9 +1025,10 @@ class SchemaAstAnalyzer {
       }
 
       if (schemaMethod == 'string' &&
-          _hasOnlyNonRestrictiveStringDiscriminatorMethods(
+          _hasOnlyNonRestrictiveDiscriminatorMethods(
             expression,
             baseInvocation,
+            baseMethod: 'string',
           )) {
         return null;
       }
@@ -1082,17 +1099,18 @@ class SchemaAstAnalyzer {
     return values;
   }
 
-  bool _hasOnlyNonRestrictiveStringDiscriminatorMethods(
+  bool _hasOnlyNonRestrictiveDiscriminatorMethods(
     MethodInvocation expression,
-    MethodInvocation baseInvocation,
-  ) {
+    MethodInvocation baseInvocation, {
+    required String baseMethod,
+  }) {
     final (chain, _) = _collectMethodChain(expression);
-    const allowedMethods = {'string', 'optional', 'nullable', 'describe'};
+    const allowedMethods = {'optional', 'nullable', 'describe'};
 
     for (final invocation in chain) {
       final methodName = invocation.methodName.name;
       if (identical(invocation, baseInvocation)) {
-        return methodName == 'string';
+        return methodName == baseMethod;
       }
       if (!allowedMethods.contains(methodName)) {
         return false;

--- a/packages/ack_generator/lib/src/analyzer/schema_ast_analyzer.dart
+++ b/packages/ack_generator/lib/src/analyzer/schema_ast_analyzer.dart
@@ -1024,15 +1024,6 @@ class SchemaAstAnalyzer {
             'which do not include "$discriminatorValue".';
       }
 
-      if (schemaMethod == 'string' &&
-          _hasOnlyNonRestrictiveDiscriminatorMethods(
-            expression,
-            baseInvocation,
-            baseMethod: 'string',
-          )) {
-        return null;
-      }
-
       return 'has discriminator property schema ${expression.toSource()} that could not be proven to accept "$discriminatorValue".';
     }
 

--- a/packages/ack_generator/lib/src/analyzer/schema_ast_analyzer.dart
+++ b/packages/ack_generator/lib/src/analyzer/schema_ast_analyzer.dart
@@ -630,7 +630,7 @@ class SchemaAstAnalyzer {
   /// - `schemas` must be a non-empty map literal
   /// - Branches must be top-level schema variable/getter references
   /// - Branches must be @AckType object schemas and non-nullable
-  /// - Branches must declare `discriminatorKey` as a matching `Ack.literal(...)`
+  /// - Branch discriminator properties may be omitted or compatible
   /// - Each branch schema can only appear once per discriminated base
   /// - Branches must be declared in the same library
   ModelInfo _parseDiscriminatedSchema(
@@ -791,30 +791,21 @@ class SchemaAstAnalyzer {
         );
       }
 
-      final branchLiteralValue = _extractDiscriminatorLiteralFromDeclaration(
-        declaration: resolvedBranch.sourceDeclaration,
-        discriminatorKey: resolvedDiscriminatorKey,
-        visitedDeclarations: <String>{},
-      );
+      final discriminatorCompatibilityError =
+          _analyzeDiscriminatorPropertyCompatibility(
+            declaration: resolvedBranch.sourceDeclaration,
+            discriminatorKey: resolvedDiscriminatorKey,
+            discriminatorValue: discriminatorValue,
+            visitedDeclarations: <String>{},
+          );
 
-      if (branchLiteralValue == null) {
+      if (discriminatorCompatibilityError != null) {
         throw InvalidGenerationSourceError(
-          'Ack.discriminated(...): branch "${resolvedBranch.schemaName}" must define '
-          '"$resolvedDiscriminatorKey" as Ack.literal("$discriminatorValue").',
+          'Ack.discriminated(...): branch "${resolvedBranch.schemaName}" '
+          '$discriminatorCompatibilityError',
           element: element,
           todo:
-              'Update the branch object schema so "$resolvedDiscriminatorKey" is a literal matching its map key.',
-        );
-      }
-
-      if (branchLiteralValue != discriminatorValue) {
-        throw InvalidGenerationSourceError(
-          'Ack.discriminated(...): branch "${resolvedBranch.schemaName}" has '
-          '"$resolvedDiscriminatorKey" literal "$branchLiteralValue", '
-          'but is mapped as "$discriminatorValue".',
-          element: element,
-          todo:
-              'Use matching values for the schemas map key and branch discriminator literal.',
+              'Omit "$resolvedDiscriminatorKey" from the branch schema, or make it accept "$discriminatorValue".',
         );
       }
 
@@ -839,33 +830,38 @@ class SchemaAstAnalyzer {
     );
   }
 
-  String? _extractDiscriminatorLiteralFromDeclaration({
+  String? _analyzeDiscriminatorPropertyCompatibility({
     required Element2 declaration,
     required String discriminatorKey,
+    required String discriminatorValue,
     required Set<String> visitedDeclarations,
   }) {
     final declarationKey = _declarationVisitKey(declaration);
     if (!visitedDeclarations.add(declarationKey)) {
-      return null;
+      return 'has a recursive discriminator property reference that cannot be analyzed.';
     }
 
     final schemaExpression = _extractSchemaExpressionForDeclaration(
       declaration,
     );
-    if (schemaExpression == null) return null;
+    if (schemaExpression == null) {
+      return 'has a discriminator property that could not be analyzed.';
+    }
 
-    return _extractDiscriminatorLiteralFromSchemaExpression(
+    return _analyzeDiscriminatorSchemaExpressionCompatibility(
       expression: schemaExpression,
       contextElement: declaration,
       discriminatorKey: discriminatorKey,
+      discriminatorValue: discriminatorValue,
       visitedDeclarations: visitedDeclarations,
     );
   }
 
-  String? _extractDiscriminatorLiteralFromSchemaExpression({
+  String? _analyzeDiscriminatorSchemaExpressionCompatibility({
     required Expression expression,
     required Element2 contextElement,
     required String discriminatorKey,
+    required String discriminatorValue,
     required Set<String> visitedDeclarations,
   }) {
     if (expression is MethodInvocation) {
@@ -875,11 +871,14 @@ class SchemaAstAnalyzer {
           schemaReferenceBase,
           contextElement,
         );
-        if (resolvedBranch == null) return null;
+        if (resolvedBranch == null) {
+          return 'has a discriminator property reference that could not be resolved.';
+        }
 
-        return _extractDiscriminatorLiteralFromDeclaration(
+        return _analyzeDiscriminatorPropertyCompatibility(
           declaration: resolvedBranch.sourceDeclaration,
           discriminatorKey: discriminatorKey,
+          discriminatorValue: discriminatorValue,
           visitedDeclarations: visitedDeclarations,
         );
       }
@@ -887,36 +886,48 @@ class SchemaAstAnalyzer {
       final baseInvocation = _findBaseAckInvocation(expression);
       if (baseInvocation == null ||
           baseInvocation.methodName.name != 'object') {
-        return null;
+        return _analyzeDiscriminatorPropertySchemaExpression(
+          expression: expression,
+          contextElement: contextElement,
+          discriminatorValue: discriminatorValue,
+          visitedDeclarations: visitedDeclarations,
+        );
       }
 
-      return _extractDiscriminatorLiteralFromObjectInvocation(
+      return _analyzeDiscriminatorObjectInvocation(
         objectInvocation: baseInvocation,
         contextElement: contextElement,
         discriminatorKey: discriminatorKey,
+        discriminatorValue: discriminatorValue,
         visitedDeclarations: visitedDeclarations,
       );
     }
 
     final schemaReference = _extractSchemaReference(expression);
-    if (schemaReference == null) return null;
+    if (schemaReference == null) {
+      return 'has a discriminator property that could not be analyzed.';
+    }
     final resolvedBranch = _resolveSchemaReference(
       schemaReference,
       contextElement,
     );
-    if (resolvedBranch == null) return null;
+    if (resolvedBranch == null) {
+      return 'has a discriminator property reference that could not be resolved.';
+    }
 
-    return _extractDiscriminatorLiteralFromDeclaration(
+    return _analyzeDiscriminatorPropertyCompatibility(
       declaration: resolvedBranch.sourceDeclaration,
       discriminatorKey: discriminatorKey,
+      discriminatorValue: discriminatorValue,
       visitedDeclarations: visitedDeclarations,
     );
   }
 
-  String? _extractDiscriminatorLiteralFromObjectInvocation({
+  String? _analyzeDiscriminatorObjectInvocation({
     required MethodInvocation objectInvocation,
     required Element2 contextElement,
     required String discriminatorKey,
+    required String discriminatorValue,
     required Set<String> visitedDeclarations,
   }) {
     final args = objectInvocation.argumentList.arguments;
@@ -933,9 +944,10 @@ class SchemaAstAnalyzer {
         continue;
       }
 
-      return _extractLiteralValueFromSchemaExpression(
+      return _analyzeDiscriminatorPropertySchemaExpression(
         expression: mapElement.value,
         contextElement: contextElement,
+        discriminatorValue: discriminatorValue,
         visitedDeclarations: visitedDeclarations,
       );
     }
@@ -943,9 +955,10 @@ class SchemaAstAnalyzer {
     return null;
   }
 
-  String? _extractLiteralValueFromSchemaExpression({
+  String? _analyzeDiscriminatorPropertySchemaExpression({
     required Expression expression,
     required Element2 contextElement,
+    required String discriminatorValue,
     required Set<String> visitedDeclarations,
   }) {
     if (expression is MethodInvocation) {
@@ -955,59 +968,138 @@ class SchemaAstAnalyzer {
           schemaReferenceBase,
           contextElement,
         );
-        if (resolved == null) return null;
+        if (resolved == null) {
+          return 'has a discriminator property reference that could not be resolved.';
+        }
 
-        return _extractLiteralValueFromDeclaration(
+        return _analyzeDiscriminatorPropertySchemaDeclaration(
           declaration: resolved.sourceDeclaration,
+          discriminatorValue: discriminatorValue,
           visitedDeclarations: visitedDeclarations,
         );
       }
 
       final baseInvocation = _findBaseAckInvocation(expression);
-      if (baseInvocation == null ||
-          baseInvocation.methodName.name != 'literal') {
+      if (baseInvocation == null) {
+        return 'has a discriminator property that could not be analyzed.';
+      }
+
+      final schemaMethod = baseInvocation.methodName.name;
+      if (schemaMethod == 'literal') {
+        final literalValue = _extractSingleStringArgument(baseInvocation);
+        if (literalValue == null) {
+          return 'has a discriminator literal that is not a string literal.';
+        }
+        if (literalValue == discriminatorValue) {
+          return null;
+        }
+        return 'has discriminator literal "$literalValue", but is mapped as "$discriminatorValue".';
+      }
+
+      if (schemaMethod == 'enumString') {
+        final allowedValues = _extractStringListArgument(baseInvocation);
+        if (allowedValues == null) {
+          return 'has an Ack.enumString(...) discriminator that is not a string list literal.';
+        }
+        if (allowedValues.contains(discriminatorValue)) {
+          return null;
+        }
+        return 'has discriminator enum values ${allowedValues.map((v) => '"$v"').join(', ')}, '
+            'which do not include "$discriminatorValue".';
+      }
+
+      if (schemaMethod == 'string' &&
+          _hasOnlyNonRestrictiveStringDiscriminatorMethods(
+            expression,
+            baseInvocation,
+          )) {
         return null;
       }
 
-      final literalArguments = baseInvocation.argumentList.arguments;
-      if (literalArguments.length != 1 ||
-          literalArguments.first is! SimpleStringLiteral) {
-        return null;
-      }
-
-      return (literalArguments.first as SimpleStringLiteral).value;
+      return 'has discriminator property schema ${expression.toSource()} that could not be proven to accept "$discriminatorValue".';
     }
 
     final schemaReference = _extractSchemaReference(expression);
-    if (schemaReference == null) return null;
+    if (schemaReference == null) {
+      return 'has a discriminator property that could not be analyzed.';
+    }
     final resolved = _resolveSchemaReference(schemaReference, contextElement);
-    if (resolved == null) return null;
+    if (resolved == null) {
+      return 'has a discriminator property reference that could not be resolved.';
+    }
 
-    return _extractLiteralValueFromDeclaration(
+    return _analyzeDiscriminatorPropertySchemaDeclaration(
       declaration: resolved.sourceDeclaration,
+      discriminatorValue: discriminatorValue,
       visitedDeclarations: visitedDeclarations,
     );
   }
 
-  String? _extractLiteralValueFromDeclaration({
+  String? _analyzeDiscriminatorPropertySchemaDeclaration({
     required Element2 declaration,
+    required String discriminatorValue,
     required Set<String> visitedDeclarations,
   }) {
     final declarationKey = _declarationVisitKey(declaration);
     if (!visitedDeclarations.add(declarationKey)) {
-      return null;
+      return 'has a recursive discriminator property reference that cannot be analyzed.';
     }
 
     final schemaExpression = _extractSchemaExpressionForDeclaration(
       declaration,
     );
-    if (schemaExpression == null) return null;
+    if (schemaExpression == null) {
+      return 'has a discriminator property reference that could not be analyzed.';
+    }
 
-    return _extractLiteralValueFromSchemaExpression(
+    return _analyzeDiscriminatorPropertySchemaExpression(
       expression: schemaExpression,
       contextElement: declaration,
+      discriminatorValue: discriminatorValue,
       visitedDeclarations: visitedDeclarations,
     );
+  }
+
+  String? _extractSingleStringArgument(MethodInvocation invocation) {
+    final arguments = invocation.argumentList.arguments;
+    if (arguments.length != 1 || arguments.first is! SimpleStringLiteral) {
+      return null;
+    }
+    return (arguments.first as SimpleStringLiteral).value;
+  }
+
+  List<String>? _extractStringListArgument(MethodInvocation invocation) {
+    final arguments = invocation.argumentList.arguments;
+    if (arguments.length != 1 || arguments.first is! ListLiteral) {
+      return null;
+    }
+
+    final values = <String>[];
+    for (final element in (arguments.first as ListLiteral).elements) {
+      if (element is! SimpleStringLiteral) return null;
+      values.add(element.value);
+    }
+    return values;
+  }
+
+  bool _hasOnlyNonRestrictiveStringDiscriminatorMethods(
+    MethodInvocation expression,
+    MethodInvocation baseInvocation,
+  ) {
+    final (chain, _) = _collectMethodChain(expression);
+    const allowedMethods = {'string', 'optional', 'nullable', 'describe'};
+
+    for (final invocation in chain) {
+      final methodName = invocation.methodName.name;
+      if (identical(invocation, baseInvocation)) {
+        return methodName == 'string';
+      }
+      if (!allowedMethods.contains(methodName)) {
+        return false;
+      }
+    }
+
+    return true;
   }
 
   String _declarationVisitKey(Element2 declaration) {

--- a/packages/ack_generator/lib/src/builders/type_builder.dart
+++ b/packages/ack_generator/lib/src/builders/type_builder.dart
@@ -216,7 +216,6 @@ class TypeBuilder {
     final baseTypeName = _getExtensionTypeName(baseModel);
     final lookups = _ModelLookups(allModels);
     final discriminatorKey = baseModel.discriminatorKey!;
-    final schemaVarName = _toCamelCase(model.schemaClassName);
 
     return ExtensionType(
       (b) => b
@@ -232,8 +231,7 @@ class TypeBuilder {
           refer('Map<String, Object?>'),
         ])
         ..methods.addAll([
-          // Override discriminator to read from _data.
-          // Factory constructors already validate the discriminator value matches
+          // Subtype factories validate through the effective branch schema.
           Method(
             (m) => m
               ..type = MethodType.getter
@@ -242,10 +240,11 @@ class TypeBuilder {
               ..lambda = true
               ..body = Code("_data['$discriminatorKey'] as String"),
           ),
-          ..._buildStaticFactories(model, schemaVarName),
+          ..._buildDiscriminatedSubtypeFactories(model, baseModel),
           // Add regular field getters
           ..._buildGetters(model, lookups, skipJsonKeys: {discriminatorKey}),
-          if (model.additionalProperties) _buildArgsGetter(model),
+          if (model.additionalProperties)
+            _buildArgsGetter(model, additionalKnownKeys: {discriminatorKey}),
         ]),
     );
   }
@@ -395,6 +394,56 @@ return $schemaVarName.parseAs(
 return $schemaVarName.safeParseAs(
   data,
   (validated) => $typeName(validated as $castType),
+);'''),
+      ),
+    ];
+  }
+
+  List<Method> _buildDiscriminatedSubtypeFactories(
+    ModelInfo model,
+    ModelInfo baseModel,
+  ) {
+    final typeName = _getExtensionTypeName(model);
+    final baseSchemaVarName = _toCamelCase(baseModel.schemaClassName);
+    final discriminatorValue = model.discriminatorValue!;
+    final effectiveBranch =
+        "$baseSchemaVarName.effectiveBranch('$discriminatorValue')";
+
+    return [
+      Method(
+        (m) => m
+          ..name = 'parse'
+          ..static = true
+          ..returns = refer(typeName)
+          ..requiredParameters.add(
+            Parameter(
+              (p) => p
+                ..name = 'data'
+                ..type = refer('Object?'),
+            ),
+          )
+          ..body = Code('''
+return $effectiveBranch.parseAs(
+  data,
+  (validated) => $typeName(validated as Map<String, Object?>),
+);'''),
+      ),
+      Method(
+        (m) => m
+          ..name = 'safeParse'
+          ..static = true
+          ..returns = _schemaResultRef(refer(typeName))
+          ..requiredParameters.add(
+            Parameter(
+              (p) => p
+                ..name = 'data'
+                ..type = refer('Object?'),
+            ),
+          )
+          ..body = Code('''
+return $effectiveBranch.safeParseAs(
+  data,
+  (validated) => $typeName(validated as Map<String, Object?>),
 );'''),
       ),
     ];
@@ -1007,8 +1056,14 @@ ${cases.join(',\n')},
   ///
   /// Returns a Map containing only properties that are not explicitly
   /// defined in the schema. This is useful when additionalProperties: true.
-  Method _buildArgsGetter(ModelInfo model) {
-    final knownKeys = model.fields.map((f) => f.jsonKey).toSet();
+  Method _buildArgsGetter(
+    ModelInfo model, {
+    Set<String> additionalKnownKeys = const {},
+  }) {
+    final knownKeys = {
+      ...additionalKnownKeys,
+      ...model.fields.map((f) => f.jsonKey),
+    };
 
     // Generate filter condition inline for better performance
     final conditions = knownKeys.map((k) => "e.key != '$k'").toList();

--- a/packages/ack_generator/test/integration/ack_type_discriminated_test.dart
+++ b/packages/ack_generator/test/integration/ack_type_discriminated_test.dart
@@ -31,7 +31,77 @@ Future<void> _expectGenerationFailure({
 
 void main() {
   group('@AckType discriminated schemas', () {
-    test('generates discriminated base and subtype extension types', () async {
+    test(
+      'generates discriminated subtypes when branches omit discriminator property',
+      () async {
+        final builder = ackGenerator(BuilderOptions.empty);
+
+        await testBuilder(
+          builder,
+          {
+            ...allAssets,
+            'test_pkg|lib/schema.dart': '''
+import 'package:ack/ack.dart';
+import 'package:ack_annotations/ack_annotations.dart';
+
+@AckType()
+final catSchema = Ack.object({
+  'lives': Ack.integer(),
+});
+
+@AckType()
+ObjectSchema get dogSchema => Ack.object({
+  'bark': Ack.boolean(),
+}).passthrough();
+
+@AckType()
+final petSchema = Ack.discriminated(
+  discriminatorKey: 'kind',
+  schemas: {
+    'cat': catSchema,
+    'dog': dogSchema,
+  },
+);
+''',
+          },
+          outputs: {
+            'test_pkg|lib/schema.g.dart': decodedMatches(
+              allOf([
+                contains('extension type PetType(Map<String, Object?> _data)'),
+                contains('implements Map<String, Object?>'),
+                contains("switch (map['kind'])"),
+                contains("'cat' => CatType(map)"),
+                contains("'dog' => DogType(map)"),
+                contains('extension type CatType(Map<String, Object?> _data)'),
+                contains('extension type DogType(Map<String, Object?> _data)'),
+                contains('implements PetType, Map<String, Object?>'),
+                contains('return petSchema.parseAs('),
+                contains('return petSchema.safeParseAs('),
+                contains(".effectiveBranch('cat')"),
+                contains(".effectiveBranch('dog')"),
+                isNot(contains('return catSchema.parseAs(')),
+                isNot(contains('return catSchema.safeParseAs(')),
+                isNot(contains('return dogSchema.parseAs(')),
+                isNot(contains('return dogSchema.safeParseAs(')),
+                isNot(contains("map['kind'] !=")),
+                isNot(contains('Expected kind')),
+                contains('Map<String, Object?> get args =>'),
+                contains("e.key != 'kind' && e.key != 'bark'"),
+                predicate((content) {
+                  final source = content as String;
+                  final count = RegExp(
+                    r"String get kind => _data\['kind'\] as String;",
+                  ).allMatches(source).length;
+                  return count == 3;
+                }, 'contains one kind getter per generated type'),
+              ]),
+            ),
+          },
+        );
+      },
+    );
+
+    test('allows existing matching discriminator literal', () async {
       final builder = ackGenerator(BuilderOptions.empty);
 
       await testBuilder(
@@ -49,17 +119,10 @@ final catSchema = Ack.object({
 });
 
 @AckType()
-ObjectSchema get dogSchema => Ack.object({
-  'kind': Ack.literal('dog'),
-  'bark': Ack.boolean(),
-}).passthrough();
-
-@AckType()
 final petSchema = Ack.discriminated(
   discriminatorKey: 'kind',
   schemas: {
     'cat': catSchema,
-    'dog': dogSchema,
   },
 );
 ''',
@@ -68,25 +131,46 @@ final petSchema = Ack.discriminated(
           'test_pkg|lib/schema.g.dart': decodedMatches(
             allOf([
               contains('extension type PetType(Map<String, Object?> _data)'),
-              contains('implements Map<String, Object?>'),
-              contains("switch (map['kind'])"),
-              contains("'cat' => CatType(map)"),
-              contains("'dog' => DogType(map)"),
               contains('extension type CatType(Map<String, Object?> _data)'),
-              contains('extension type DogType(Map<String, Object?> _data)'),
-              contains('implements PetType, Map<String, Object?>'),
-              contains('return catSchema.parseAs('),
-              contains('return catSchema.safeParseAs('),
-              contains('return dogSchema.parseAs('),
-              contains('return dogSchema.safeParseAs('),
-              contains('Map<String, Object?> get args =>'),
-              predicate((content) {
-                final source = content as String;
-                final count = RegExp(
-                  r"String get kind => _data\['kind'\] as String;",
-                ).allMatches(source).length;
-                return count == 3;
-              }, 'contains one kind getter per generated type'),
+              contains("String get kind => _data['kind'] as String;"),
+            ]),
+          ),
+        },
+      );
+    });
+
+    test('allows existing broad string discriminator property', () async {
+      final builder = ackGenerator(BuilderOptions.empty);
+
+      await testBuilder(
+        builder,
+        {
+          ...allAssets,
+          'test_pkg|lib/schema.dart': '''
+import 'package:ack/ack.dart';
+import 'package:ack_annotations/ack_annotations.dart';
+
+@AckType()
+final catSchema = Ack.object({
+  'kind': Ack.string(),
+  'lives': Ack.integer(),
+});
+
+@AckType()
+final petSchema = Ack.discriminated(
+  discriminatorKey: 'kind',
+  schemas: {
+    'cat': catSchema,
+  },
+);
+''',
+        },
+        outputs: {
+          'test_pkg|lib/schema.g.dart': decodedMatches(
+            allOf([
+              contains('extension type PetType(Map<String, Object?> _data)'),
+              contains('extension type CatType(Map<String, Object?> _data)'),
+              contains("String get kind => _data['kind'] as String;"),
             ]),
           ),
         },

--- a/packages/ack_generator/test/integration/ack_type_discriminated_test.dart
+++ b/packages/ack_generator/test/integration/ack_type_discriminated_test.dart
@@ -139,7 +139,7 @@ final petSchema = Ack.discriminated(
       );
     });
 
-    test('allows existing broad string discriminator property', () async {
+    test('allows existing matching discriminator enum', () async {
       final builder = ackGenerator(BuilderOptions.empty);
 
       await testBuilder(
@@ -152,7 +152,7 @@ import 'package:ack_annotations/ack_annotations.dart';
 
 @AckType()
 final catSchema = Ack.object({
-  'kind': Ack.string(),
+  'kind': Ack.enumString(['cat', 'kitty']),
   'lives': Ack.integer(),
 });
 
@@ -173,6 +173,36 @@ final petSchema = Ack.discriminated(
               contains("String get kind => _data['kind'] as String;"),
             ]),
           ),
+        },
+      );
+    });
+
+    test('fails when branch discriminator property is broad string', () async {
+      final builder = ackGenerator(BuilderOptions.empty);
+
+      await _expectGenerationFailure(
+        builder: builder,
+        expectedMessage: 'could not be proven to accept "cat"',
+        assets: {
+          ...allAssets,
+          'test_pkg|lib/schema.dart': '''
+import 'package:ack/ack.dart';
+import 'package:ack_annotations/ack_annotations.dart';
+
+@AckType()
+final catSchema = Ack.object({
+  'kind': Ack.string(),
+  'lives': Ack.integer(),
+});
+
+@AckType()
+final petSchema = Ack.discriminated(
+  discriminatorKey: 'kind',
+  schemas: {
+    'cat': catSchema,
+  },
+);
+''',
         },
       );
     });

--- a/packages/ack_generator/test/integration/ack_type_discriminated_test.dart
+++ b/packages/ack_generator/test/integration/ack_type_discriminated_test.dart
@@ -177,6 +177,72 @@ final petSchema = Ack.discriminated(
       );
     });
 
+    test(
+      'fails when matching discriminator literal has restrictive chain',
+      () async {
+        final builder = ackGenerator(BuilderOptions.empty);
+
+        await _expectGenerationFailure(
+          builder: builder,
+          expectedMessage: 'could not be proven to accept "cat"',
+          assets: {
+            ...allAssets,
+            'test_pkg|lib/schema.dart': '''
+import 'package:ack/ack.dart';
+import 'package:ack_annotations/ack_annotations.dart';
+
+@AckType()
+final catSchema = Ack.object({
+  'kind': Ack.literal('cat').minLength(4),
+  'lives': Ack.integer(),
+});
+
+@AckType()
+final petSchema = Ack.discriminated(
+  discriminatorKey: 'kind',
+  schemas: {
+    'cat': catSchema,
+  },
+);
+''',
+          },
+        );
+      },
+    );
+
+    test(
+      'fails when matching discriminator enum has restrictive chain',
+      () async {
+        final builder = ackGenerator(BuilderOptions.empty);
+
+        await _expectGenerationFailure(
+          builder: builder,
+          expectedMessage: 'could not be proven to accept "cat"',
+          assets: {
+            ...allAssets,
+            'test_pkg|lib/schema.dart': '''
+import 'package:ack/ack.dart';
+import 'package:ack_annotations/ack_annotations.dart';
+
+@AckType()
+final catSchema = Ack.object({
+  'kind': Ack.enumString(['cat']).minLength(4),
+  'lives': Ack.integer(),
+});
+
+@AckType()
+final petSchema = Ack.discriminated(
+  discriminatorKey: 'kind',
+  schemas: {
+    'cat': catSchema,
+  },
+);
+''',
+          },
+        );
+      },
+    );
+
     test('fails when a branch is an inline expression', () async {
       final builder = ackGenerator(BuilderOptions.empty);
 

--- a/packages/ack_json_schema_builder/test/to_json_schema_builder_test.dart
+++ b/packages/ack_json_schema_builder/test/to_json_schema_builder_test.dart
@@ -324,6 +324,28 @@ void main() {
         expect(oneOf, isNotNull);
         expect(oneOf, hasLength(2));
       });
+
+      test(
+        'oneOf accepts compatible existing discriminator property as singleton enum',
+        () {
+          final schema = Ack.discriminated(
+            discriminatorKey: 'kind',
+            schemas: {
+              'a': Ack.object({'kind': Ack.string(), 'val': Ack.string()}),
+            },
+          );
+          final result = schema.toJsonSchemaBuilder();
+
+          final oneOf = result.value['oneOf'] as List;
+          final branch = _schemaFrom(oneOf.single);
+          final properties = (branch.value['properties'] as Map).map(
+            (key, value) => MapEntry(key as String, _schemaFrom(value)),
+          );
+
+          expect(properties['kind']!.value['enum'], ['a']);
+          expect(branch.value['required'], ['kind', 'val']);
+        },
+      );
     });
 
     group('Numeric constraints - exclusive bounds and multipleOf', () {
@@ -403,12 +425,12 @@ void main() {
     });
 
     group('Discriminated + error wrapping', () {
-      test('throws on discriminator/property conflict', () {
+      test('throws when branch discriminator rejects branch key', () {
         final schema = Ack.discriminated(
           discriminatorKey: 'type',
           schemas: {
             'circle': Ack.object({
-              'type': Ack.string(), // conflict
+              'type': Ack.literal('square'),
               'radius': Ack.double(),
             }),
           },

--- a/packages/ack_json_schema_builder/test/to_json_schema_builder_test.dart
+++ b/packages/ack_json_schema_builder/test/to_json_schema_builder_test.dart
@@ -331,7 +331,10 @@ void main() {
           final schema = Ack.discriminated(
             discriminatorKey: 'kind',
             schemas: {
-              'a': Ack.object({'kind': Ack.string(), 'val': Ack.string()}),
+              'a': Ack.object({
+                'kind': Ack.enumString(['a', 'alpha']),
+                'val': Ack.string(),
+              }),
             },
           );
           final result = schema.toJsonSchemaBuilder();


### PR DESCRIPTION
## Summary

- Branches in `Ack.discriminated(...)` no longer need to redeclare the discriminator property; the union owns it and synthesizes an effective branch with the literal injected first for validation and JSON Schema export.
- If a branch declares the discriminator property, it must be `Ack.literal(...)` matching the branch key or `Ack.enumString(...)` containing the branch key. Broad `Ack.string()`, transformed/refined discriminator fields, and restrictive discriminator chains are rejected.
- Adds `DiscriminatedObjectSchema.effectiveBranch`, the `effectiveDiscriminatedBranch` util, and `TransformedSchema.copyWithSchema`; refactors `ack_generator` to emit subtype `parse`/`safeParse` via the union effective branch and updates docs, examples, and tests.

## Test plan

- [x] `melos run build --no-select`
- [x] `melos run analyze --no-select`
- [x] `melos run test:dart --no-select`
- [x] `melos run test:flutter --no-select`
- [x] `melos run validate-jsonschema --no-select`
- [x] `git diff --check`