### PR TITLE
chore(deps): clean up package dependency scopes

### DIFF
--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -10,6 +10,7 @@ environment:
 
 dependencies:
   ack: ^1.0.0-beta.8
+  ack_annotations: ^1.0.0-beta.11
 
 dev_dependencies:
   ack_generator: ^1.0.0-beta.8

--- a/packages/ack_firebase_ai/pubspec.yaml
+++ b/packages/ack_firebase_ai/pubspec.yaml
@@ -11,13 +11,13 @@ environment:
 
 dependencies:
   ack: ^1.0.0-beta.12-wip
-  firebase_ai: ^3.12.1
   flutter:
     sdk: flutter
 
 dev_dependencies:
   firebase_core: ^4.9.0
   firebase_core_platform_interface: ^7.0.1
+  firebase_ai: ^3.12.1
   flutter_test:
     sdk: flutter
   lints: ^5.0.0

--- a/packages/ack_generator/pubspec.yaml
+++ b/packages/ack_generator/pubspec.yaml
@@ -22,7 +22,6 @@ dependencies:
   # Utilities
   collection: ^1.18.0
   logging: ^1.3.0
-  path: ^1.9.0
   meta: ^1.15.0
   dart_style: ^3.1.0
 
@@ -30,6 +29,7 @@ dev_dependencies:
   build_runner: ^2.1.7
   build_test: ^3.1.0
   test: ^1.25.15
+  path: ^1.9.0
   # Code quality
   lints: ^5.0.0
   


### PR DESCRIPTION
## Summary
- Move `path` in `ack_generator` to `dev_dependencies` because it is only used by tests/tooling.
- Move `firebase_ai` in `ack_firebase_ai` to `dev_dependencies` because package library code does not import it directly.
- Add `ack_annotations` to the example dependencies because `example/lib` imports it directly.

## Validation
- `dart analyze . --fatal-warnings --fatal-infos` for all workspace packages
- `dependency_validator --verbose -C <package>` for each package
- `dart test` in `packages/ack`, `packages/ack_generator`, `packages/ack_json_schema_builder`, and `example`
- `flutter test` in `packages/ack_firebase_ai`
- `cd tools && npm install --silent && npx depcheck --json`

## Notes
- Melos orchestration is blocked in this workspace because `pubspec.yaml` points to `.fvm/flutter_sdk`, which is not present locally, so validation used direct package-level commands.
