### PR TITLE
chore(release): 1.0.0-beta.12

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '22'
       
       - name: Install docs.page CLI
         run: npm install -g @docs.page/cli

--- a/docs.json
+++ b/docs.json
@@ -68,7 +68,7 @@
   ],
   "variables": {
     "versions": {
-      "default": "0.2.0",
+      "default": "1.0.0-beta.12",
       "isPrerelease": true
     }
   },

--- a/llms.txt
+++ b/llms.txt
@@ -1,6 +1,6 @@
 # Ack
 
-> A schema validation library for Dart and Flutter with a fluent runtime API and `@AckType()`-driven extension-type generation. Version 1.0.0-beta.12-wip.
+> A schema validation library for Dart and Flutter with a fluent runtime API and `@AckType()`-driven extension-type generation. Version 1.0.0-beta.12.
 
 Ack validates external data with hand-written schemas built using the `Ack`
 factory. When you want typed wrappers over validated values, annotate top-level

--- a/packages/ack/CHANGELOG.md
+++ b/packages/ack/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 1.0.0-beta.12
 
 ### Breaking Changes
 

--- a/packages/ack/lib/src/constraints/duration_constraint.dart
+++ b/packages/ack/lib/src/constraints/duration_constraint.dart
@@ -9,7 +9,7 @@ enum DurationComparisonType { min, max }
 /// inclusive range checking (on or after for min, on or before for max, in
 /// milliseconds).
 ///
-/// Used internally by [Ack.duration()] schemas when applying [.min()] or [.max()]
+/// Used internally by [Ack.duration] schemas when applying `min()` or `max()`
 /// constraints.
 class DurationConstraint extends Constraint<Duration>
     with Validator<Duration>, JsonSchemaSpec<Duration> {

--- a/packages/ack/lib/src/schemas/extensions/numeric_extensions.dart
+++ b/packages/ack/lib/src/schemas/extensions/numeric_extensions.dart
@@ -130,7 +130,7 @@ extension NumberSchemaExtensions on NumberSchema {
   /// Adds a constraint that the number must be finite.
   ///
   /// Numbers are finite by default; this method is kept for API symmetry with
-  /// [DoubleSchema.finite].
+  /// [DoubleSchemaExtensions.finite].
   NumberSchema finite() {
     return withConstraint(NumberFiniteConstraint<num>());
   }

--- a/packages/ack/pubspec.yaml
+++ b/packages/ack/pubspec.yaml
@@ -1,6 +1,6 @@
 name: ack
 description: A simple validation library for Dart
-version: 1.0.0-beta.12-wip
+version: 1.0.0-beta.12
 repository: https://github.com/btwld/ack
 issue_tracker: https://github.com/btwld/ack/issues
 homepage: https://docs.page/btwld/ack

--- a/packages/ack_annotations/CHANGELOG.md
+++ b/packages/ack_annotations/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.0.0-beta.12-wip
+## 1.0.0-beta.12
 
 ### Breaking
 

--- a/packages/ack_annotations/README.md
+++ b/packages/ack_annotations/README.md
@@ -7,11 +7,11 @@
 
 ```yaml
 dependencies:
-  ack: ^1.0.0-beta.12-wip
-  ack_annotations: ^1.0.0-beta.12-wip
+  ack: ^1.0.0-beta.12
+  ack_annotations: ^1.0.0-beta.12
 
 dev_dependencies:
-  ack_generator: ^1.0.0-beta.12-wip
+  ack_generator: ^1.0.0-beta.12
   build_runner: ^2.4.0
 ```
 

--- a/packages/ack_annotations/pubspec.yaml
+++ b/packages/ack_annotations/pubspec.yaml
@@ -1,6 +1,6 @@
 name: ack_annotations
 description: AckType annotation for schema extension-type generation
-version: 1.0.0-beta.12-wip
+version: 1.0.0-beta.12
 repository: https://github.com/btwld/ack
 resolution: workspace
 

--- a/packages/ack_firebase_ai/CHANGELOG.md
+++ b/packages/ack_firebase_ai/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 1.0.0-beta.12
 
 ### Added
 - Added `toFirebaseAiResponseJsonSchema()` for Firebase AI's
@@ -16,7 +16,7 @@
 - Target Firebase AI `^3.12.1` and models that support JSON Schema
   structured output.
 - Default Firebase AI examples and live tests to `gemini-3.5-flash`.
-- Require `ack` `^1.0.0-beta.12-wip` for the sealed `AckSchemaModel`
+- Require `ack` `^1.0.0-beta.12` for the sealed `AckSchemaModel`
   adapter boundary.
 - Keep `firebase_ai` and Flutter as explicit package dependencies so package
   tests and workspace orchestration use the Firebase AI SDK runtime.

--- a/packages/ack_firebase_ai/README.md
+++ b/packages/ack_firebase_ai/README.md
@@ -23,8 +23,8 @@ Always validate model output with the same ACK schema after generation. Firebase
 
 ```yaml
 dependencies:
-  ack: ^1.0.0-beta.12-wip
-  ack_firebase_ai: ^1.0.0-beta.12-wip
+  ack: ^1.0.0-beta.12
+  ack_firebase_ai: ^1.0.0-beta.12
   firebase_ai: ^3.12.1
 ```
 

--- a/packages/ack_firebase_ai/pubspec.yaml
+++ b/packages/ack_firebase_ai/pubspec.yaml
@@ -1,6 +1,6 @@
 name: ack_firebase_ai
 description: Firebase AI (Gemini) schema converter for ACK validation library
-version: 1.0.0-beta.12-wip
+version: 1.0.0-beta.12
 repository: https://github.com/btwld/ack
 issue_tracker: https://github.com/btwld/ack/issues
 resolution: workspace
@@ -10,7 +10,7 @@ environment:
   flutter: '>=3.16.0'
 
 dependencies:
-  ack: ^1.0.0-beta.12-wip
+  ack: ^1.0.0-beta.12
   flutter:
     sdk: flutter
 

--- a/packages/ack_firebase_ai/pubspec.yaml
+++ b/packages/ack_firebase_ai/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
 dev_dependencies:
   firebase_core: ^4.9.0
   firebase_core_platform_interface: ^7.0.1
-  firebase_ai: ^3.12.1
+  firebase_ai: '>=3.12.1 <3.13.0'
   flutter_test:
     sdk: flutter
   lints: ^5.0.0

--- a/packages/ack_generator/CHANGELOG.md
+++ b/packages/ack_generator/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.0.0-beta.12-wip
+## 1.0.0-beta.12
 
 ### Breaking
 

--- a/packages/ack_generator/README.md
+++ b/packages/ack_generator/README.md
@@ -38,11 +38,11 @@ extension type UserType(Map<String, Object?> _data)
 
 ```yaml
 dependencies:
-  ack: ^1.0.0-beta.12-wip
-  ack_annotations: ^1.0.0-beta.12-wip
+  ack: ^1.0.0-beta.12
+  ack_annotations: ^1.0.0-beta.12
 
 dev_dependencies:
-  ack_generator: ^1.0.0-beta.12-wip
+  ack_generator: ^1.0.0-beta.12
   build_runner: ^2.4.0
 ```
 

--- a/packages/ack_generator/pubspec.yaml
+++ b/packages/ack_generator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: ack_generator
 description: Code generator for AckType extension-type generation
-version: 1.0.0-beta.12-wip
+version: 1.0.0-beta.12
 repository: https://github.com/btwld/ack
 issue_tracker: https://github.com/btwld/ack/issues
 resolution: workspace
@@ -16,8 +16,8 @@ dependencies:
   code_builder: ^4.10.0
   
   # Ack packages (versions are overridden locally by Melos)
-  ack: ^1.0.0-beta.11
-  ack_annotations: ^1.0.0-beta.11
+  ack: ^1.0.0-beta.12
+  ack_annotations: ^1.0.0-beta.12
   
   # Utilities
   collection: ^1.18.0

--- a/packages/ack_json_schema_builder/CHANGELOG.md
+++ b/packages/ack_json_schema_builder/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 1.0.0-beta.12
 
 ### Changed
 
@@ -6,7 +6,7 @@
   Draft-7 JSON Schema renderer.
 * Preserve model defaults, const values, extension keywords, transformed
   metadata, and composition.
-* Require `ack` `^1.0.0-beta.12-wip` for the sealed `AckSchemaModel`
+* Require `ack` `^1.0.0-beta.12` for the sealed `AckSchemaModel`
   adapter boundary.
 
 ### Removed

--- a/packages/ack_json_schema_builder/README.md
+++ b/packages/ack_json_schema_builder/README.md
@@ -12,8 +12,8 @@ Converts ACK schemas to json_schema_builder format via `.toJsonSchemaBuilder()`.
 
 ```yaml
 dependencies:
-  ack: ^1.0.0-beta.12-wip
-  ack_json_schema_builder: ^1.0.0-beta.12-wip
+  ack: ^1.0.0-beta.12
+  ack_json_schema_builder: ^1.0.0-beta.12
   json_schema_builder: ^0.1.3
 ```
 

--- a/packages/ack_json_schema_builder/pubspec.yaml
+++ b/packages/ack_json_schema_builder/pubspec.yaml
@@ -1,6 +1,6 @@
 name: ack_json_schema_builder
 description: JSON Schema Builder converter for ACK validation library
-version: 1.0.0-beta.12-wip
+version: 1.0.0-beta.12
 repository: https://github.com/btwld/ack
 issue_tracker: https://github.com/btwld/ack/issues
 resolution: workspace
@@ -9,7 +9,7 @@ environment:
   sdk: '>=3.8.0 <4.0.0'
 
 dependencies:
-  ack: ^1.0.0-beta.12-wip
+  ack: ^1.0.0-beta.12
   json_schema_builder: ^0.1.3
 
 dev_dependencies:


### PR DESCRIPTION
## Release `1.0.0-beta.12`

Finalizes the in-progress `1.0.0-beta.12-wip` prep into a publishable `1.0.0-beta.12` across all packages.

### Changes
- **Versions:** `1.0.0-beta.12-wip` → `1.0.0-beta.12` for all 5 packages (`ack`, `ack_annotations`, `ack_generator`, `ack_firebase_ai`, `ack_json_schema_builder`).
- **Internal dep constraints:**
  - `ack_firebase_ai`, `ack_json_schema_builder`: `ack: ^1.0.0-beta.12-wip` → `^1.0.0-beta.12` (required — `1.0.0-beta.12` does **not** satisfy a `-wip` constraint; numeric `12` sorts below alphanumeric `12-wip` in semver).
  - `ack_generator`: `ack` / `ack_annotations` `^1.0.0-beta.11` → `^1.0.0-beta.12` (lockstep).
- **CHANGELOGs:** top section retitled to `## 1.0.0-beta.12` (detail kept inline).
- **Docs/READMEs:** remaining `-wip` references updated; `docs.json` default version `0.2.0` → `1.0.0-beta.12`; `llms.txt` version line updated.
- **Dartdoc fixes** (separate commit): repair unresolved references in `duration_constraint.dart` and `numeric_extensions.dart`.

### Releasing after merge
Publishing is automated via `.github/workflows/release.yml` (→ `btwld/dart-actions/publish.yml`, OIDC), triggered by a version tag:

```sh
gh release create v1.0.0-beta.12 --target main --title v1.0.0-beta.12 --notes-file <notes>
# or: git tag v1.0.0-beta.12 && git push origin v1.0.0-beta.12
```

Packages publish in dependency order (`ack` → `ack_annotations` → `ack_generator` → `ack_json_schema_builder` → `ack_firebase_ai`).

### Pre-flight before tagging
- [ ] `melos run test` (analyze `--fatal-infos` + Dart/Flutter tests)
- [ ] `dart pub publish --dry-run` in each package
- [ ] Automated publishing enabled on pub.dev for each package

⚠️ Publishing to pub.dev is permanent.
