### PR TITLE
chore(release): prepare 1.0.0

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -6,7 +6,8 @@
 
 ## Repository layout
 - `packages/ack`: core runtime validation library.
-- `packages/ack_annotations`: source annotations (`@AckModel`, `@AckType`).
+- `packages/ack_annotations`: source annotation for `@AckType()` schema
+  generation.
 - `packages/ack_generator`: build_runner generator + golden tests.
 - `packages/ack_firebase_ai`: Firebase AI schema adapter.
 - `packages/ack_json_schema_builder`: JSON Schema adapter.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,20 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 1.0.0 - 2026-06-26
+
+Stable 1.0 release for the Ack workspace.
+
+### Highlights
+
+- Finalized the core validation API, codecs, JSON Schema export, Firebase AI
+  adapter, json_schema_builder adapter, and `@AckType()` extension-type
+  generation docs for the stable release.
+- Removed deprecated public helpers and the internal legacy `MapValue` alias so
+  the 1.0 API surface is clean.
+- Reworked the documentation site around task-first guides, validated examples,
+  and concise API reference material.
+
 ## 2026-03-02
 
 ### Changes
@@ -547,4 +561,3 @@ Packages with other changes:
 #### `ack` - `v0.2.0`
 
  - Bump "ack" to 0.2.0 with improved SchemaModel API and enhanced string validation
-

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,56 @@
+# Contributing to Ack
+
+Thanks for helping improve Ack. Keep changes focused, tested, and easy to
+review.
+
+## Development setup
+
+```bash
+dart pub global activate melos
+melos bootstrap
+```
+
+Ack uses a Melos workspace. Run commands from the repository root unless a
+package README says otherwise.
+
+## Before opening a PR
+
+1. Keep the change scoped to one problem.
+2. Add or update tests for behavior changes.
+3. Update docs or README snippets when public APIs, examples, or setup steps
+   change.
+4. Run the relevant checks:
+
+```bash
+melos analyze
+melos test
+```
+
+For code generation changes, also run:
+
+```bash
+melos run test:gen
+```
+
+For JSON Schema export changes, also run:
+
+```bash
+melos run validate-jsonschema
+```
+
+## Commit style
+
+Use Conventional Commits, for example:
+
+```text
+feat(ack): add schema helper
+fix(generator): preserve nullable list getters
+docs: clarify codec examples
+```
+
+Use `!` or a `BREAKING CHANGE:` footer for breaking API changes.
+
+## Release notes
+
+User-facing changes should update the relevant package `CHANGELOG.md`. Release
+publishing is handled by maintainers through `PUBLISHING.md`.

--- a/docs.json
+++ b/docs.json
@@ -75,8 +75,8 @@
   ],
   "variables": {
     "versions": {
-      "default": "1.0.0-beta.12",
-      "isPrerelease": true
+      "default": "1.0.0",
+      "isPrerelease": false
     }
   },
   "search": {},

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,6 +1,6 @@
 name: ack_example
 description: Example project for ACK schema generation.
-version: 1.0.0-beta.1
+version: 1.0.0
 publish_to: none
 
 resolution: workspace
@@ -9,11 +9,11 @@ environment:
   sdk: '>=3.8.0 <4.0.0'
 
 dependencies:
-  ack: ^1.0.0-beta.12
-  ack_annotations: ^1.0.0-beta.12
+  ack: ^1.0.0
+  ack_annotations: ^1.0.0
 
 dev_dependencies:
-  ack_generator: ^1.0.0-beta.12
+  ack_generator: ^1.0.0
   build_runner: ^2.4.0
   dart_code_metrics_presets: ^2.22.0
   lints: ^5.0.0

--- a/llms.txt
+++ b/llms.txt
@@ -1,6 +1,6 @@
 # Ack
 
-> A schema validation library for Dart and Flutter with a fluent runtime API and `@AckType()`-driven extension-type generation. Version 1.0.0-beta.12.
+> A schema validation library for Dart and Flutter with a fluent runtime API and `@AckType()`-driven extension-type generation. Version 1.0.0.
 
 Ack validates external data with hand-written schemas built using the `Ack`
 factory. When you want typed wrappers over validated values, annotate top-level

--- a/packages/ack/CHANGELOG.md
+++ b/packages/ack/CHANGELOG.md
@@ -1,3 +1,24 @@
+## 1.0.0
+
+### Added
+
+* Documented codecs as a stable API for bidirectional conversions between wire
+  values and Dart runtime values.
+* Added and tested codec examples for built-in codecs and custom `Ack.codec`
+  round trips.
+
+### Changed
+
+* Prepared the documentation site and README for the stable 1.0 release with a
+  task-first quickstart, clearer guide flow, and validated API examples.
+
+### Removed
+
+* Removed the deprecated `StringSchema.enumString()` and
+  `StringSchema.literal()` instance helpers. Use the stable
+  `Ack.enumString(...)` and `Ack.literal(...)` factories instead.
+* Removed the internal legacy `MapValue` alias in favor of `JsonMap`.
+
 ## 1.0.0-beta.12
 
 ### Breaking Changes

--- a/packages/ack/README.md
+++ b/packages/ack/README.md
@@ -12,7 +12,7 @@ Ack is a schema validation library for Dart and Flutter that helps you validate 
 - **Validate external payloads**: Guard API and user inputs by validating required fields, types, and constraints at boundaries
 - **Single Source of Truth**: Define data structures and rules in one place
 - **Reduce Boilerplate**: Minimize repetitive code for validation and JSON conversion
-- **Type Safety**: Generate type-safe schema classes from your Dart models
+- **Type Safety**: Generate typed wrappers for hand-written Ack schemas
 
 ## Quick Start
 
@@ -55,6 +55,6 @@ Use `.optional()` when a field may be omitted entirely. Chain `.nullable()` if a
 
 ## Related Packages
 
-- [ack_generator](https://pub.dev/packages/ack_generator) — Code generator for creating schema classes from annotated Dart models
+- [ack_generator](https://pub.dev/packages/ack_generator) — Code generator for typed wrappers from `@AckType()` schemas
 - [ack_firebase_ai](https://pub.dev/packages/ack_firebase_ai) — Firebase AI (Gemini) schema converter
 - [ack_json_schema_builder](https://pub.dev/packages/ack_json_schema_builder) — JSON Schema converter

--- a/packages/ack/pubspec.yaml
+++ b/packages/ack/pubspec.yaml
@@ -1,6 +1,6 @@
 name: ack
 description: A simple validation library for Dart
-version: 1.0.0-beta.12
+version: 1.0.0
 repository: https://github.com/btwld/ack
 issue_tracker: https://github.com/btwld/ack/issues
 homepage: https://docs.page/btwld/ack

--- a/packages/ack_annotations/CHANGELOG.md
+++ b/packages/ack_annotations/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 1.0.0
+
+### Changed
+
+* Marked the `@AckType()` annotation package stable for Ack 1.0.
+* Updated examples and installation snippets to use stable Ack package
+  constraints.
+
 ## 1.0.0-beta.12
 
 ### Breaking

--- a/packages/ack_annotations/README.md
+++ b/packages/ack_annotations/README.md
@@ -7,11 +7,11 @@
 
 ```yaml
 dependencies:
-  ack: ^1.0.0-beta.12
-  ack_annotations: ^1.0.0-beta.12
+  ack: ^1.0.0
+  ack_annotations: ^1.0.0
 
 dev_dependencies:
-  ack_generator: ^1.0.0-beta.12
+  ack_generator: ^1.0.0
   build_runner: ^2.4.0
 ```
 

--- a/packages/ack_annotations/pubspec.yaml
+++ b/packages/ack_annotations/pubspec.yaml
@@ -1,6 +1,6 @@
 name: ack_annotations
 description: AckType annotation for schema extension-type generation
-version: 1.0.0-beta.12
+version: 1.0.0
 repository: https://github.com/btwld/ack
 resolution: workspace
 

--- a/packages/ack_firebase_ai/CHANGELOG.md
+++ b/packages/ack_firebase_ai/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.0.0
+
+### Changed
+
+* Marked the Firebase AI `responseJsonSchema` adapter stable for Ack 1.0.
+* Updated installation snippets and docs to use stable Ack package constraints.
+
 ## 1.0.0-beta.12
 
 ### Added

--- a/packages/ack_firebase_ai/README.md
+++ b/packages/ack_firebase_ai/README.md
@@ -23,8 +23,8 @@ Always validate model output with the same ACK schema after generation. Firebase
 
 ```yaml
 dependencies:
-  ack: ^1.0.0-beta.12
-  ack_firebase_ai: ^1.0.0-beta.12
+  ack: ^1.0.0
+  ack_firebase_ai: ^1.0.0
   firebase_ai: ^3.12.1
 ```
 

--- a/packages/ack_firebase_ai/pubspec.yaml
+++ b/packages/ack_firebase_ai/pubspec.yaml
@@ -1,6 +1,6 @@
 name: ack_firebase_ai
 description: Firebase AI (Gemini) schema converter for ACK validation library
-version: 1.0.0-beta.12
+version: 1.0.0
 repository: https://github.com/btwld/ack
 issue_tracker: https://github.com/btwld/ack/issues
 resolution: workspace
@@ -10,7 +10,7 @@ environment:
   flutter: '>=3.16.0'
 
 dependencies:
-  ack: ^1.0.0-beta.12
+  ack: ^1.0.0
   flutter:
     sdk: flutter
 

--- a/packages/ack_generator/CHANGELOG.md
+++ b/packages/ack_generator/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 1.0.0
+
+### Changed
+
+* Marked top-level `@AckType()` schema generation stable for Ack 1.0.
+* Updated generator documentation around supported schemas, discriminated
+  unions, typed getters, and stable dependency constraints.
+
 ## 1.0.0-beta.12
 
 ### Breaking

--- a/packages/ack_generator/README.md
+++ b/packages/ack_generator/README.md
@@ -38,11 +38,11 @@ extension type UserType(Map<String, Object?> _data)
 
 ```yaml
 dependencies:
-  ack: ^1.0.0-beta.12
-  ack_annotations: ^1.0.0-beta.12
+  ack: ^1.0.0
+  ack_annotations: ^1.0.0
 
 dev_dependencies:
-  ack_generator: ^1.0.0-beta.12
+  ack_generator: ^1.0.0
   build_runner: ^2.4.0
 ```
 

--- a/packages/ack_generator/pubspec.yaml
+++ b/packages/ack_generator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: ack_generator
 description: Code generator for AckType extension-type generation
-version: 1.0.0-beta.12
+version: 1.0.0
 repository: https://github.com/btwld/ack
 issue_tracker: https://github.com/btwld/ack/issues
 resolution: workspace
@@ -16,8 +16,8 @@ dependencies:
   code_builder: ^4.10.0
   
   # Ack packages (versions are overridden locally by Melos)
-  ack: ^1.0.0-beta.12
-  ack_annotations: ^1.0.0-beta.12
+  ack: ^1.0.0
+  ack_annotations: ^1.0.0
   
   # Utilities
   collection: ^1.18.0

--- a/packages/ack_json_schema_builder/CHANGELOG.md
+++ b/packages/ack_json_schema_builder/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.0.0
+
+### Changed
+
+* Marked the json_schema_builder adapter stable for Ack 1.0.
+* Updated installation snippets and docs to use stable Ack package constraints.
+
 ## 1.0.0-beta.12
 
 ### Changed

--- a/packages/ack_json_schema_builder/README.md
+++ b/packages/ack_json_schema_builder/README.md
@@ -12,8 +12,8 @@ Converts ACK schemas to json_schema_builder format via `.toJsonSchemaBuilder()`.
 
 ```yaml
 dependencies:
-  ack: ^1.0.0-beta.12
-  ack_json_schema_builder: ^1.0.0-beta.12
+  ack: ^1.0.0
+  ack_json_schema_builder: ^1.0.0
   json_schema_builder: ^0.1.3
 ```
 

--- a/packages/ack_json_schema_builder/pubspec.yaml
+++ b/packages/ack_json_schema_builder/pubspec.yaml
@@ -1,6 +1,6 @@
 name: ack_json_schema_builder
 description: JSON Schema Builder converter for ACK validation library
-version: 1.0.0-beta.12
+version: 1.0.0
 repository: https://github.com/btwld/ack
 issue_tracker: https://github.com/btwld/ack/issues
 resolution: workspace
@@ -9,7 +9,7 @@ environment:
   sdk: '>=3.8.0 <4.0.0'
 
 dependencies:
-  ack: ^1.0.0-beta.12
+  ack: ^1.0.0
   json_schema_builder: ^0.1.3
 
 dev_dependencies:


### PR DESCRIPTION
## Summary
- Bump all publishable Ack packages to 1.0.0 and update internal dependency constraints to ^1.0.0
- Mark docs metadata and llms.txt as stable 1.0.0
- Add concise 1.0.0 changelog entries and CONTRIBUTING.md
- Clean up remaining contributor-facing stale @AckModel wording

## Verification
- dart pub get
- npx @docs.page/cli check
- dart test test/documentation (from packages/ack): 124 passed
- dart analyze . --fatal-infos in packages/ack, ack_annotations, ack_generator, ack_json_schema_builder, example
- flutter analyze . --fatal-infos in packages/ack_firebase_ai
- dart test in packages/ack: 922 passed
- dart test in packages/ack_generator: 130 passed
- dart test in packages/ack_json_schema_builder: 49 passed
- dart test in example: 105 passed
- flutter test in packages/ack_firebase_ai: 98 passed, 4 live tests skipped without credentials
- dart pub publish --dry-run for ack, ack_annotations, ack_generator, ack_json_schema_builder: 0 warnings
- flutter pub publish --dry-run for ack_firebase_ai: 0 warnings

## Publish note
After this PR merges, publish by creating the GitHub Release/tag v1.0.0 per PUBLISHING.md. I did not create the tag or publish packages from this branch.