### PR TITLE
docs: link 1.0 changelogs to release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,17 +5,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ## 1.0.0 - 2026-06-26
 
-Stable 1.0 release for the Ack workspace.
-
-### Highlights
-
-- Finalized the core validation API, codecs, JSON Schema export, Firebase AI
-  adapter, json_schema_builder adapter, and `@AckType()` extension-type
-  generation docs for the stable release.
-- Removed deprecated public helpers and the internal legacy `MapValue` alias so
-  the 1.0 API surface is clean.
-- Reworked the documentation site around task-first guides, validated examples,
-  and concise API reference material.
+* See [release notes](https://github.com/btwld/ack/releases/tag/v1.0.0) for details.
 
 ## 2026-03-02
 

--- a/packages/ack/CHANGELOG.md
+++ b/packages/ack/CHANGELOG.md
@@ -1,23 +1,6 @@
 ## 1.0.0
 
-### Added
-
-* Documented codecs as a stable API for bidirectional conversions between wire
-  values and Dart runtime values.
-* Added and tested codec examples for built-in codecs and custom `Ack.codec`
-  round trips.
-
-### Changed
-
-* Prepared the documentation site and README for the stable 1.0 release with a
-  task-first quickstart, clearer guide flow, and validated API examples.
-
-### Removed
-
-* Removed the deprecated `StringSchema.enumString()` and
-  `StringSchema.literal()` instance helpers. Use the stable
-  `Ack.enumString(...)` and `Ack.literal(...)` factories instead.
-* Removed the internal legacy `MapValue` alias in favor of `JsonMap`.
+* See [release notes](https://github.com/btwld/ack/releases/tag/v1.0.0) for details.
 
 ## 1.0.0-beta.12
 

--- a/packages/ack_annotations/CHANGELOG.md
+++ b/packages/ack_annotations/CHANGELOG.md
@@ -1,10 +1,6 @@
 ## 1.0.0
 
-### Changed
-
-* Marked the `@AckType()` annotation package stable for Ack 1.0.
-* Updated examples and installation snippets to use stable Ack package
-  constraints.
+* See [release notes](https://github.com/btwld/ack/releases/tag/v1.0.0) for details.
 
 ## 1.0.0-beta.12
 

--- a/packages/ack_firebase_ai/CHANGELOG.md
+++ b/packages/ack_firebase_ai/CHANGELOG.md
@@ -1,9 +1,6 @@
 ## 1.0.0
 
-### Changed
-
-* Marked the Firebase AI `responseJsonSchema` adapter stable for Ack 1.0.
-* Updated installation snippets and docs to use stable Ack package constraints.
+* See [release notes](https://github.com/btwld/ack/releases/tag/v1.0.0) for details.
 
 ## 1.0.0-beta.12
 

--- a/packages/ack_generator/CHANGELOG.md
+++ b/packages/ack_generator/CHANGELOG.md
@@ -1,10 +1,6 @@
 ## 1.0.0
 
-### Changed
-
-* Marked top-level `@AckType()` schema generation stable for Ack 1.0.
-* Updated generator documentation around supported schemas, discriminated
-  unions, typed getters, and stable dependency constraints.
+* See [release notes](https://github.com/btwld/ack/releases/tag/v1.0.0) for details.
 
 ## 1.0.0-beta.12
 

--- a/packages/ack_json_schema_builder/CHANGELOG.md
+++ b/packages/ack_json_schema_builder/CHANGELOG.md
@@ -1,9 +1,6 @@
 ## 1.0.0
 
-### Changed
-
-* Marked the json_schema_builder adapter stable for Ack 1.0.
-* Updated installation snippets and docs to use stable Ack package constraints.
+* See [release notes](https://github.com/btwld/ack/releases/tag/v1.0.0) for details.
 
 ## 1.0.0-beta.12
 


### PR DESCRIPTION
## Summary
- Replace detailed 1.0.0 entries in the root and package changelogs with a single link to the v1.0.0 GitHub release notes
- Preserve historical beta changelog entries

## Verification
- git diff --check
- Confirmed each 1.0.0 changelog entry links to https://github.com/btwld/ack/releases/tag/v1.0.0
- Confirmed beta history remains in package changelogs