### PR TITLE
chore(release): prepare 1.0.1

### DIFF
--- a/packages/ack_annotations/CHANGELOG.md
+++ b/packages/ack_annotations/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.1
+
+* See [release notes](https://github.com/btwld/ack/releases/tag/v1.0.1) for details.
+
 ## 1.0.0
 
 * See [release notes](https://github.com/btwld/ack/releases/tag/v1.0.0) for details.

--- a/packages/ack_annotations/pubspec.yaml
+++ b/packages/ack_annotations/pubspec.yaml
@@ -1,6 +1,6 @@
 name: ack_annotations
 description: AckType annotation for schema extension-type generation
-version: 1.0.0
+version: 1.0.1
 repository: https://github.com/btwld/ack
 resolution: workspace
 

--- a/packages/ack_firebase_ai/CHANGELOG.md
+++ b/packages/ack_firebase_ai/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.1
+
+* See [release notes](https://github.com/btwld/ack/releases/tag/v1.0.1) for details.
+
 ## 1.0.0
 
 * See [release notes](https://github.com/btwld/ack/releases/tag/v1.0.0) for details.

--- a/packages/ack_firebase_ai/pubspec.yaml
+++ b/packages/ack_firebase_ai/pubspec.yaml
@@ -1,6 +1,6 @@
 name: ack_firebase_ai
 description: Firebase AI (Gemini) schema converter for ACK validation library
-version: 1.0.0
+version: 1.0.1
 repository: https://github.com/btwld/ack
 issue_tracker: https://github.com/btwld/ack/issues
 resolution: workspace

--- a/packages/ack_generator/CHANGELOG.md
+++ b/packages/ack_generator/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.1
+
+* See [release notes](https://github.com/btwld/ack/releases/tag/v1.0.1) for details.
+
 ## 1.0.0
 
 * See [release notes](https://github.com/btwld/ack/releases/tag/v1.0.0) for details.

--- a/packages/ack_generator/pubspec.yaml
+++ b/packages/ack_generator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: ack_generator
 description: Code generator for AckType extension-type generation
-version: 1.0.0
+version: 1.0.1
 repository: https://github.com/btwld/ack
 issue_tracker: https://github.com/btwld/ack/issues
 resolution: workspace

--- a/packages/ack_json_schema_builder/CHANGELOG.md
+++ b/packages/ack_json_schema_builder/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.1
+
+* See [release notes](https://github.com/btwld/ack/releases/tag/v1.0.1) for details.
+
 ## 1.0.0
 
 * See [release notes](https://github.com/btwld/ack/releases/tag/v1.0.0) for details.

--- a/packages/ack_json_schema_builder/pubspec.yaml
+++ b/packages/ack_json_schema_builder/pubspec.yaml
@@ -1,6 +1,6 @@
 name: ack_json_schema_builder
 description: JSON Schema Builder converter for ACK validation library
-version: 1.0.0
+version: 1.0.1
 repository: https://github.com/btwld/ack
 issue_tracker: https://github.com/btwld/ack/issues
 resolution: workspace


### PR DESCRIPTION
## Release 1.0.1

Prepares the **1.0.1** release. The substantive change — the `Ack.lazy` / `LazySchema` recursion-depth guard (`maxDepth`, default 100) — already landed on `main` via #122, which also bumped `packages/ack` to `1.0.1`.

This PR version-aligns the remaining publishable packages so the release workflow (which publishes all 5 together) runs clean:

- `ack_annotations`, `ack_generator`, `ack_json_schema_builder`, `ack_firebase_ai`: `1.0.0` → `1.0.1` + link-only CHANGELOG entries.
- No functional changes in these 4 packages; `ack: ^1.0.0` constraints already permit `1.0.1`, so no dependency edits.

### Verification
- `dart pub publish --dry-run` passes for all 5 packages (only warning is the pre-commit "modified in git" notice).
- `dart analyze` clean across `ack` + the changed pure-Dart packages.

Once merged, a GitHub Release `v1.0.1` will be cut to publish all 5 to pub.dev.