### PR TITLE
chore(release): prepare 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## Unreleased
+## 1.1.0 - 2026-07-12
 
 * Fix validation edge cases, schema export consistency, schema immutability,
   generator diagnostics, and workspace/release tooling reliability.

--- a/llms.txt
+++ b/llms.txt
@@ -1,6 +1,6 @@
 # Ack
 
-> A schema validation library for Dart and Flutter with a fluent runtime API and `@AckType()`-driven extension-type generation. Version 1.0.1.
+> A schema validation library for Dart and Flutter with a fluent runtime API and `@AckType()`-driven extension-type generation. Version 1.1.0.
 
 Ack validates external data with hand-written schemas built using the `Ack`
 factory. When you want typed wrappers over validated values, annotate top-level

--- a/packages/ack/CHANGELOG.md
+++ b/packages/ack/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 1.1.0
 
 ### Fixed
 

--- a/packages/ack/pubspec.yaml
+++ b/packages/ack/pubspec.yaml
@@ -1,6 +1,6 @@
 name: ack
 description: A simple validation library for Dart
-version: 1.0.1
+version: 1.1.0
 repository: https://github.com/btwld/ack
 issue_tracker: https://github.com/btwld/ack/issues
 homepage: https://docs.page/btwld/ack

--- a/packages/ack_annotations/CHANGELOG.md
+++ b/packages/ack_annotations/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.0
+
+* See [release notes](https://github.com/btwld/ack/releases/tag/v1.1.0) for details.
+
 ## 1.0.1
 
 * See [release notes](https://github.com/btwld/ack/releases/tag/v1.0.1) for details.

--- a/packages/ack_annotations/pubspec.yaml
+++ b/packages/ack_annotations/pubspec.yaml
@@ -1,6 +1,6 @@
 name: ack_annotations
 description: AckType annotation for schema extension-type generation
-version: 1.0.1
+version: 1.1.0
 repository: https://github.com/btwld/ack
 resolution: workspace
 

--- a/packages/ack_firebase_ai/CHANGELOG.md
+++ b/packages/ack_firebase_ai/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.0
+
+* See [release notes](https://github.com/btwld/ack/releases/tag/v1.1.0) for details.
+
 ## 1.0.1
 
 * See [release notes](https://github.com/btwld/ack/releases/tag/v1.0.1) for details.

--- a/packages/ack_firebase_ai/pubspec.yaml
+++ b/packages/ack_firebase_ai/pubspec.yaml
@@ -1,6 +1,6 @@
 name: ack_firebase_ai
 description: Firebase AI (Gemini) schema converter for ACK validation library
-version: 1.0.1
+version: 1.1.0
 repository: https://github.com/btwld/ack
 issue_tracker: https://github.com/btwld/ack/issues
 resolution: workspace

--- a/packages/ack_generator/CHANGELOG.md
+++ b/packages/ack_generator/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 1.1.0
 
 ### Changed
 

--- a/packages/ack_generator/pubspec.yaml
+++ b/packages/ack_generator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: ack_generator
 description: Code generator for AckType extension-type generation
-version: 1.0.1
+version: 1.1.0
 repository: https://github.com/btwld/ack
 issue_tracker: https://github.com/btwld/ack/issues
 resolution: workspace

--- a/packages/ack_json_schema_builder/CHANGELOG.md
+++ b/packages/ack_json_schema_builder/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.0
+
+* See [release notes](https://github.com/btwld/ack/releases/tag/v1.1.0) for details.
+
 ## 1.0.1
 
 * See [release notes](https://github.com/btwld/ack/releases/tag/v1.0.1) for details.

--- a/packages/ack_json_schema_builder/pubspec.yaml
+++ b/packages/ack_json_schema_builder/pubspec.yaml
@@ -1,6 +1,6 @@
 name: ack_json_schema_builder
 description: JSON Schema Builder converter for ACK validation library
-version: 1.0.1
+version: 1.1.0
 repository: https://github.com/btwld/ack
 issue_tracker: https://github.com/btwld/ack/issues
 resolution: workspace


### PR DESCRIPTION
## Summary

- version all five publishable Ack packages as 1.1.0
- finalize the detailed Ack and generator behavior-change changelogs
- add 1.1.0 release-note links for the lockstep packages
- update the workspace changelog and `llms.txt` version

This is the release-preparation commit for the correctness work merged in
#124. Publishing is intentionally not triggered by this PR; after it merges, a
GitHub Release tagged `v1.1.0` will run the automated pub.dev workflow.

## Verification

- `dart scripts/api_check.dart 1.0.1` — no API changes in all five packages
- `dart run melos run test --no-select`
- `dart run melos run test:gen --no-select`
- `dart run melos run validate-jsonschema --no-select`
- `dart pub publish --dry-run` — all five packages, zero warnings
